### PR TITLE
Additional Japanese holidays.

### DIFF
--- a/src/Assets/ManageDates/Templates/HolidaysDefinition.json
+++ b/src/Assets/ManageDates/Templates/HolidaysDefinition.json
@@ -1830,6 +1830,183 @@
       "HolidayName": "Christmas Day",
       "SubstituteHoliday": "NoSubstituteHoliday",
       "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 1,
+      "DayNumber": 1,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "New Year's Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 1,
+      "DayNumber": 0,
+      "WeekDayNumber": 1,
+      "OffsetWeek": 2,
+      "OffsetDays": 0,
+      "HolidayName": "Coming of Age Day",
+      "SubstituteHoliday": "NoSubstituteHoliday",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 2,
+      "DayNumber": 11,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "National Foundation Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 2,
+      "DayNumber": 23,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "The Emperor's Birthday",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "FirstYear": 2020
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 3,
+      "DayNumber": 21,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Vernal Equinox Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 4,
+      "DayNumber": 29,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Shōwa Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 5,
+      "DayNumber": 3,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Constitution Memorial Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 5,
+      "DayNumber": 4,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "	Greenery Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 5,
+      "DayNumber": 5,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Children's Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 7,
+      "DayNumber": 0,
+      "WeekDayNumber": 1,
+      "OffsetWeek": 3,
+      "OffsetDays": 0,
+      "HolidayName": "Marine Day",
+      "SubstituteHoliday": "NoSubstituteHoliday",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 8,
+      "DayNumber": 11,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Mountain Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 9,
+      "DayNumber": 0,
+      "WeekDayNumber": 1,
+      "OffsetWeek": 3,
+      "OffsetDays": 0,
+      "HolidayName": "Respect for the Aged Day",
+      "SubstituteHoliday": "NoSubstituteHoliday",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 9,
+      "DayNumber": 21,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Autumnal Equinox Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 10,
+      "DayNumber": 0,
+      "WeekDayNumber": 1,
+      "OffsetWeek": 2,
+      "OffsetDays": 0,
+      "HolidayName": "Sports Day",
+      "SubstituteHoliday": "NoSubstituteHoliday",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 11,
+      "DayNumber": 3,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Culture Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 11,
+      "DayNumber": 23,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Labour Thanksgiving Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
     }
   ]
 }

--- a/src/Assets/ManageDates/Templates/HolidaysDefinition.json
+++ b/src/Assets/ManageDates/Templates/HolidaysDefinition.json
@@ -1967,7 +1967,7 @@
     {
       "IsoCountry": "JP",
       "MonthNumber": 9,
-      "DayNumber": 21,
+      "DayNumber": 23,
       "WeekDayNumber": 0,
       "OffsetWeek": 0,
       "OffsetDays": 0,

--- a/src/Assets/ManageDates/Templates/HolidaysDefinition.json
+++ b/src/Assets/ManageDates/Templates/HolidaysDefinition.json
@@ -1845,13 +1845,26 @@
     {
       "IsoCountry": "JP",
       "MonthNumber": 1,
+      "DayNumber": 15,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Coming of Age Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "LastYear": 1999
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 1,
       "DayNumber": 0,
       "WeekDayNumber": 1,
       "OffsetWeek": 2,
       "OffsetDays": 0,
       "HolidayName": "Coming of Age Day",
       "SubstituteHoliday": "NoSubstituteHoliday",
-      "ConflictPriority": 100
+      "ConflictPriority": 100,
+      "FirstYear": 2000
     },
     {
       "IsoCountry": "JP",
@@ -1878,7 +1891,7 @@
     },
     {
       "IsoCountry": "JP",
-      "MonthNumber": 2,
+      "MonthNumber": 12,
       "DayNumber": 23,
       "WeekDayNumber": 0,
       "OffsetWeek": 0,
@@ -1887,7 +1900,7 @@
       "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
       "ConflictPriority": 100,
       "FirstYear": 1989,
-      "LastYear": 2019
+      "LastYear": 2018
     },
     {
       "IsoCountry": "JP",
@@ -1907,9 +1920,35 @@
       "WeekDayNumber": 0,
       "OffsetWeek": 0,
       "OffsetDays": 0,
+      "HolidayName": "The Emperor's Birthday",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "LastYear": 1988
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 4,
+      "DayNumber": 29,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Greenery Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "FirstYear": 1989,
+      "LastYear": 2006
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 4,
+      "DayNumber": 29,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
       "HolidayName": "Shōwa Day",
       "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
-      "ConflictPriority": 100
+      "ConflictPriority": 100,
+      "FirstYear": 2007
     },
     {
       "IsoCountry": "JP",
@@ -1929,7 +1968,7 @@
       "WeekDayNumber": 0,
       "OffsetWeek": 0,
       "OffsetDays": 0,
-      "HolidayName": "	Greenery Day",
+      "HolidayName": "Greenery Day",
       "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
       "ConflictPriority": 100
     },
@@ -1947,13 +1986,26 @@
     {
       "IsoCountry": "JP",
       "MonthNumber": 7,
+      "DayNumber": 20,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Marine Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "LastYear": 2002
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 7,
       "DayNumber": 0,
       "WeekDayNumber": 1,
       "OffsetWeek": 3,
       "OffsetDays": 0,
       "HolidayName": "Marine Day",
       "SubstituteHoliday": "NoSubstituteHoliday",
-      "ConflictPriority": 100
+      "ConflictPriority": 100,
+      "FirstYear": 2003
     },
     {
       "IsoCountry": "JP",
@@ -1964,7 +2016,20 @@
       "OffsetDays": 0,
       "HolidayName": "Mountain Day",
       "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
-      "ConflictPriority": 100
+      "ConflictPriority": 100,
+      "FirstYear": 2016
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 9,
+      "DayNumber": 15,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Respect for the Aged Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "LastYear": 2002
     },
     {
       "IsoCountry": "JP",
@@ -1975,7 +2040,8 @@
       "OffsetDays": 0,
       "HolidayName": "Respect for the Aged Day",
       "SubstituteHoliday": "NoSubstituteHoliday",
-      "ConflictPriority": 100
+      "ConflictPriority": 100,
+      "FirstYear": 2003
     },
     {
       "IsoCountry": "JP",
@@ -1985,6 +2051,17 @@
       "OffsetWeek": 0,
       "OffsetDays": 0,
       "HolidayName": "Autumnal Equinox Day",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100
+    },
+    {
+      "IsoCountry": "JP",
+      "MonthNumber": 10,
+      "DayNumber": 10,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "Sports Day",
       "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
       "ConflictPriority": 100
     },

--- a/src/Assets/ManageDates/Templates/HolidaysDefinition.json
+++ b/src/Assets/ManageDates/Templates/HolidaysDefinition.json
@@ -1878,6 +1878,19 @@
     },
     {
       "IsoCountry": "JP",
+      "MonthNumber": 2,
+      "DayNumber": 23,
+      "WeekDayNumber": 0,
+      "OffsetWeek": 0,
+      "OffsetDays": 0,
+      "HolidayName": "The Emperor's Birthday",
+      "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
+      "ConflictPriority": 100,
+      "FirstYear": 1989,
+      "LastYear": 2019
+    },
+    {
+      "IsoCountry": "JP",
       "MonthNumber": 3,
       "DayNumber": 21,
       "WeekDayNumber": 0,


### PR DESCRIPTION
Hi, I have added Japanese holidays to HolidaysDefinition.json. Please enable "Bravo" to output Japanese holidays table as well.

However, there are two complicated setup days for Japanese holidays. This is because the length of the day and night are calculated and set as holidays every year. The dates change. The formula in Excel and the URL to check the list of dates are attached below.

Vernal Equinox Day → March
The date can be obtained in Excel using the following formula.
INT(20.8431+0.242194*([Current Year]-1980))-INT((([Current Year]-1980)/4)

Autumnal Equinox Day → September
The date can be found in Excel using the following formula.
INT(23.2488+0.242194*([Current Year]-1980))-INT((([Current Year]-1980)/4)

Currently, the dates are set to 21 March and 23 September.

Bravo is a great tool. Please support Japanese holidays too!



https://ja.wikipedia.org/wiki/Template:%E6%98%A5%E5%88%86%E6%97%A5%E3%81%A8%E7%A7%8B%E5%88%86%E6%97%A5%E3%81%AE%E4%B8%80%E8%A6%A7
![image](https://user-images.githubusercontent.com/8947320/160654791-b536e7ae-e253-40c7-aace-3b9cbb05d7d1.png)
