### PR TITLE
Download updates according to app type

### DIFF
--- a/installer/wix/src/Bravo/Bravo-perUser.wxs
+++ b/installer/wix/src/Bravo/Bravo-perUser.wxs
@@ -144,6 +144,7 @@
       <Component Id="app.exe" Guid="{E880F50A-6C3B-4EB6-B639-752803CEF497}" Win64="$(var.Win64)">
         <File Id="app.exe" Name="$(var.AppExecutableName)" Source="$(var.PublishFolder)\$(var.AppExecutableName)" Checksum="yes" KeyPath="yes" />
         <RemoveFile Id="REMOVEALL" Directory="INSTALLFOLDER" Name="*.*" On="both" />
+        <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\$(var.AppName)" Name="installFolder" Value="[INSTALLFOLDER]" Type="string" />
         <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\$(var.AppName)" Name="desktopShortcutEnabled" Value="[DESKTOPSHORTCUTENABLED]" Type="string" />
         <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\$(var.AppName)" Name="programMenuShortcutEnabled" Value="[PROGRAMMENUSHORTCUTENABLED]" Type="string" />
         <RegistryValue Root="HKCU" Key="Software\[Manufacturer]\$(var.AppName)" Name="installerTelemetryEnabled" Value="[INSTALLERTELEMETRYENABLED]" Type="string" />

--- a/installer/wix/src/Bravo/Bravo-perUser.wxs
+++ b/installer/wix/src/Bravo/Bravo-perUser.wxs
@@ -11,10 +11,10 @@
   <?define AppName = "Bravo" ?>
   
   <?if $(sys.BUILDARCH) = x64 ?>
-    <?define ProductName = "!(loc.ProductName)" ?>
+    <?define ProductName = "!(loc.ProductName) (User)" ?>
     <?define Win64 = "yes" ?>
   <?else ?>
-    <?define ProductName = "!(loc.ProductName) (32 bit)" ?>
+    <?define ProductName = "!(loc.ProductName) (User/32bit)" ?>
     <?define Win64 = "no" ?>
   <?endif ?>
   

--- a/src/Infrastructure/AppEnvironment.cs
+++ b/src/Infrastructure/AppEnvironment.cs
@@ -13,11 +13,16 @@
     using System.Diagnostics;
     using System.Drawing;
     using System.IO;
+    using System.Linq;
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
     internal static class AppEnvironment
     {
+        private static readonly Lazy<bool> _isInstalledPerMachineAppInstance;
+        private static readonly Lazy<bool> _isInstalledPerUserAppInstance;
+        private static readonly Lazy<bool> _isFrameworkDependantAppInstance;
+
         public static readonly string ApiAuthenticationSchema = "BravoAuth";
         public static readonly string ApiAuthenticationToken = Cryptography.GenerateSimpleToken();
         public static readonly string ApplicationManufacturer = "SQLBI";
@@ -26,8 +31,9 @@
         public static readonly string ApplicationStoreAliasName = "BravoStore";
         public static readonly string ApplicationMainWindowTitle = "Bravo for Power BI";
         public static readonly string ApplicationInstanceUniqueName = $"{ApplicationName}-{Guid.NewGuid():D}";
-        public static readonly string ApplicationRegistryKeyName = $@"{ Registry.LocalMachine.Name }\SOFTWARE\{ ApplicationManufacturer }\{ ApplicationName }";
+        public static readonly string ApplicationRegistryKeyName = $@"SOFTWARE\{ ApplicationManufacturer }\{ ApplicationName }";
         public static readonly string ApplicationRegistryApplicationTelemetryEnableValue = "applicationTelemetryEnabled";
+        public static readonly string ApplicationRegistryApplicationInstallFolderValue = "installFolder";
         public static readonly bool TelemetryEnabledDefault = true;
         public static readonly string TelemetryInstrumentationKey = "47a8970c-6293-408a-9cce-5b7b311574d3";
         public static readonly string PBIDesktopProcessName = "PBIDesktop";
@@ -37,7 +43,6 @@
         public static readonly Color ThemeColorDark = ColorTranslator.FromHtml("#202020");
         public static readonly Color ThemeColorLight = ColorTranslator.FromHtml("#F3F3F3");
         public static readonly DaxLineBreakStyle FormatDaxLineBreakDefault = DaxLineBreakStyle.InitialLineBreak;
-
 
         public static readonly string[] TrustedUriHosts = new[]
         {
@@ -77,6 +82,10 @@
             Diagnostics = new ConcurrentDictionary<string, DiagnosticMessage>();
             DefaultJsonOptions = new(JsonSerializerDefaults.Web) { MaxDepth = 32 }; // see Microsoft.AspNetCore.Mvc.JsonOptions.JsonSerializerOptions
             DefaultJsonOptions.Converters.Add(new JsonStringEnumMemberConverter()); // https://github.com/dotnet/runtime/issues/31081#issuecomment-578459083
+
+            _isInstalledPerMachineAppInstance = new(() => IsRunningFromInstallFolder(Registry.LocalMachine));
+            _isInstalledPerUserAppInstance = new(() => IsRunningFromInstallFolder(Registry.CurrentUser));
+            _isFrameworkDependantAppInstance = new(() => IsFrameworkDependantPublishMode());
         }
 
         /// <summary>
@@ -93,7 +102,37 @@
         /// Returns true if the current app istance is running as packaged application
         /// </summary>
         public static bool IsPackagedAppInstance { get; }
-    
+
+        /// <summary>
+        /// Returns true if the current app istance was published as a framework-dependent mode
+        /// </summary>
+        public static bool IsFrameworkDependantAppInstance => _isFrameworkDependantAppInstance.Value;
+
+        /// <summary>
+        /// Returns true if the current app istance was installed from portable ZIP package
+        /// </summary>
+        public static bool IsPortableAppInstance => !IsPackagedAppInstance && !IsInstalledAppInstance;
+
+        /// <summary>
+        /// Returns true if the current app istance was installed from an MSI package
+        /// </summary>
+        public static bool IsInstalledAppInstance => IsInstalledPerMachineAppInstance || IsInstalledPerUserAppInstance;
+
+        /// <summary>
+        /// Returns true if the current app istance was installed from a per-machine MSI package
+        /// </summary>
+        public static bool IsInstalledPerMachineAppInstance => _isInstalledPerMachineAppInstance.Value;
+
+        /// <summary>
+        /// Returns true if the current app istance was installed from a per-user MSI package
+        /// </summary>
+        public static bool IsInstalledPerUserAppInstance => _isInstalledPerUserAppInstance.Value;
+
+        /// <summary>
+        /// Returns the HKEY registry key used to install the current application instance. Returns null if it is a packaged or portable app instance
+        /// </summary>
+        public static RegistryKey? ApplicationInstallerRegistryHKey => IsInstalledPerMachineAppInstance ? Registry.LocalMachine : IsInstalledPerUserAppInstance ? Registry.CurrentUser : null;
+
         public static string ApplicationFileVersion { get; }
 
         public static string ApplicationProductVersion { get; }
@@ -166,6 +205,43 @@
                     ExceptionHelper.WriteToEventLog(ex, EventLogEntryType.Warning, throwOnError: false);
                 }
             }
+        }
+
+        private static bool IsRunningFromInstallFolder(RegistryKey registryKey)
+        {
+            if (IsPackagedAppInstance)
+                return false;
+
+            using var registrySubKey = registryKey.OpenSubKey(ApplicationRegistryKeyName, writable: false);
+
+            if (registrySubKey is not null)
+            {
+                var value = registrySubKey.GetValue(ApplicationRegistryApplicationInstallFolderValue, defaultValue: null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+                if (value != null)
+                {
+                    var valueKind = registrySubKey.GetValueKind(ApplicationRegistryApplicationInstallFolderValue);
+                    if (valueKind == RegistryValueKind.String)
+                    {
+                        var valueString = (string)value;
+                        var installPath = CommonHelper.NormalizePath(valueString);
+                        var runningPath = CommonHelper.NormalizePath(AppContext.BaseDirectory);
+
+                        return installPath == runningPath;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsFrameworkDependantPublishMode()
+        {
+            var coreclrFound = Directory.EnumerateFiles(AppContext.BaseDirectory).Any((name) =>
+            {
+                return Path.GetFileName(name).EqualsI("coreclr.dll");
+            });
+
+            return !coreclrFound;
         }
     }
 }

--- a/src/Infrastructure/AppWindow.cs
+++ b/src/Infrastructure/AppWindow.cs
@@ -145,19 +145,23 @@
             // This behavior is enabled by default to allow toast notifications because, without a valid shortcut installed, Photino cannot raise a toast notification from a desktop app.
             // If the user has chosen to activate the application shortcut during app installation, this results in a duplicate of the application shortcut in the Windows start menu.
             // The issue has been reported on GitHub, meanwhile let's get rid of the shortcut created by Photino https://github.com/tryphotino/photino.NET/issues/85
-            
-            var shortcutName = Path.ChangeExtension(AppEnvironment.ApplicationMainWindowTitle, "lnk");
-            var shortcutPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify), @"Microsoft\Windows\Start Menu\Programs", shortcutName);
-           
-            if (File.Exists(shortcutPath))
+
+            // Remove only if per-machine, don't delete the shortcut if the current instance of the app is portable or per-user
+            if (AppEnvironment.IsInstalledPerMachineAppInstance)
             {
-                try
+                var shortcutName = Path.ChangeExtension(AppEnvironment.ApplicationMainWindowTitle, "lnk");
+                var shortcutPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify), @"Microsoft\Windows\Start Menu\Programs", shortcutName);
+
+                if (File.Exists(shortcutPath))
                 {
-                    File.Delete(shortcutPath);
-                }
-                catch (IOException)
-                {
-                    // ignore "The process cannot access the file '..\Bravo for Power BI.lnk' because it is being used by another process."
+                    try
+                    {
+                        File.Delete(shortcutPath);
+                    }
+                    catch (IOException)
+                    {
+                        // ignore "The process cannot access the file '..\Bravo for Power BI.lnk' because it is being used by another process."
+                    }
                 }
             }
         }

--- a/src/Infrastructure/AppWindow.cs
+++ b/src/Infrastructure/AppWindow.cs
@@ -146,8 +146,8 @@
             // If the user has chosen to activate the application shortcut during app installation, this results in a duplicate of the application shortcut in the Windows start menu.
             // The issue has been reported on GitHub, meanwhile let's get rid of the shortcut created by Photino https://github.com/tryphotino/photino.NET/issues/85
 
-            // Remove only if per-machine, don't delete the shortcut if the current instance of the app is portable or per-user
-            if (AppEnvironment.IsInstalledPerMachineAppInstance)
+            // TODO: remove the shortcut only if the current instance is per-machine or per-user installed
+            // if (AppEnvironment.IsInstalledAppInstance)
             {
                 var shortcutName = Path.ChangeExtension(AppEnvironment.ApplicationMainWindowTitle, "lnk");
                 var shortcutPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify), @"Microsoft\Windows\Start Menu\Programs", shortcutName);

--- a/src/Infrastructure/Configuration/UserPreferences.cs
+++ b/src/Infrastructure/Configuration/UserPreferences.cs
@@ -92,14 +92,27 @@
 
         private static void UpdateFromRegistry(UserSettings settings)
         {
-            var registryObject = Registry.GetValue(AppEnvironment.ApplicationRegistryKeyName, AppEnvironment.ApplicationRegistryApplicationTelemetryEnableValue, null);
-            if (registryObject is not null)
-            {
-                var registryValue = Convert.ToString(registryObject);
+            var registryKey = AppEnvironment.ApplicationInstallerRegistryHKey;
+            if (registryKey is null)
+                return;
 
-                if (int.TryParse(registryValue, out var intValue))
+            using var registrySubKey = registryKey.OpenSubKey(AppEnvironment.ApplicationRegistryKeyName, writable: false);
+
+            if (registrySubKey is not null)
+            {
+                var value = registrySubKey.GetValue(AppEnvironment.ApplicationRegistryApplicationTelemetryEnableValue, defaultValue: null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+                if (value is not null)
                 {
-                    settings.TelemetryEnabled = Convert.ToBoolean(intValue);
+                    var valueKind = registrySubKey.GetValueKind(AppEnvironment.ApplicationRegistryApplicationTelemetryEnableValue);
+                    if (valueKind == RegistryValueKind.String)
+                    {
+                        var valueString = (string)value;
+
+                        if (int.TryParse(valueString, out var intValue))
+                        {
+                            settings.TelemetryEnabled = Convert.ToBoolean(intValue);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
- The update file to be downloaded is identified according to the app deployment type (perUser/perMachine/frameworkdependant/etc)
- Added the string suffix _(User)_ to the app name in the control panel and to the menu shortcut when the distribution type is "perUser".