### PR TITLE
Fix TelemetryEnabled does not honor registry setting

### DIFF
--- a/src/Infrastructure/Configuration/UserPreferences.cs
+++ b/src/Infrastructure/Configuration/UserPreferences.cs
@@ -112,6 +112,10 @@
                         {
                             settings.TelemetryEnabled = Convert.ToBoolean(intValue);
                         }
+                        else
+                        {
+                            settings.TelemetryEnabled = false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
TelemetryEnabled does not update correctly from the 'applicationTelemetryEnableValue' registry setting