### PR TITLE
Fix NullReferenceException/TOMDatabaseDatabaseNotFound

### DIFF
--- a/src/Infrastructure/Services/ConnectionWrapper.cs
+++ b/src/Infrastructure/Services/ConnectionWrapper.cs
@@ -64,18 +64,20 @@
             return connection;
         }
 
-        private static TabularConnectionWrapper ConnectTo(string connectionString, string databaseName, bool findById)
+        private static TabularConnectionWrapper ConnectTo(string connectionString, string databaseIdOrName, bool findById)
         {
-            var server = new TOM.Server();
+            using var server = new TOM.Server();
 
             ProcessHelper.RunOnUIThread(() =>
             {
                 server.Connect(connectionString.ToUnprotectedString());
             });
 
-            var database = findById ? server.Databases.Find(databaseName) : server.Databases.FindByName(databaseName) ?? throw new BravoException(BravoProblem.TOMDatabaseDatabaseNotFound, databaseName);
-            var connection = new TabularConnectionWrapper(connectionString, server, database);
+            var database = findById ? server.Databases.Find(databaseIdOrName) : server.Databases.FindByName(databaseIdOrName);
+            if (database is null)
+                throw new BravoException(BravoProblem.TOMDatabaseDatabaseNotFound, databaseIdOrName);
 
+            var connection = new TabularConnectionWrapper(connectionString, server, database);
             return connection;
         }
     }

--- a/src/Models/FormatDax/FormatDaxResponse.cs
+++ b/src/Models/FormatDax/FormatDaxResponse.cs
@@ -1,5 +1,6 @@
 ﻿namespace Sqlbi.Bravo.Models.FormatDax
 {
+    using Dax.Formatter.Models;
     using Sqlbi.Bravo.Infrastructure;
     using System.Collections.Generic;
     using System.Text.Json.Serialization;
@@ -42,5 +43,15 @@
 
         [JsonPropertyName("message")]
         public string? Message { get; set; }
+
+        public static FormatterError CreateFrom(DaxFormatterError error)
+        {
+            return new FormatterError
+            {
+                Line = error.Line,
+                Column = error.Column,
+                Message = error.Message
+            };
+        }
     }
 }

--- a/src/Services/FormatDaxService.cs
+++ b/src/Services/FormatDaxService.cs
@@ -61,12 +61,7 @@
                     else
                     {
                         formattedMeasure.Expression = requestedMeasure.Expression; // in case of errors returns the original expression, as requested by Daniele
-                        formattedMeasure.Errors = daxformatterResponse.Errors?.Select((e) => new FormatterError
-                        {
-                            Line = e.Line,
-                            Column = e.Column,
-                            Message = e.Message
-                        });
+                        formattedMeasure.Errors = daxformatterResponse.Errors?.Select(FormatterError.CreateFrom);
                     }
 
                     formattedMeasures.Add(formattedMeasure);


### PR DESCRIPTION
A `NullReferenceException` is raised instead of a `TOMDatabaseDatabaseNotFound` error