### PR TITLE
Fixed special date FORMAT locale for eastern Asian languages

### DIFF
--- a/src/Assets/ManageDates/Templates/DateTemplate-01.json
+++ b/src/Assets/ManageDates/Templates/DateTemplate-01.json
@@ -27,6 +27,18 @@
       "Name": "__WorkingDays",
       "Expression": "@@GETCONFIG( WorkingDays )",
       "IsConfigurable": true
+    },
+    {
+      "Name": "__IsStandardLocale",
+      "Expression": "IF ( FORMAT( DATE( 2000, 1, 1 ), \"oooo\"@@GETISO() ) = \"oooo\", TRUE, FALSE )"
+    },
+    {
+      "Name": "__DayFormatString",
+      "Expression": "IF( __IsStandardLocale, \"ddd\", \"aaa\" )"
+    },
+    {
+      "Name": "__MonthFormatString",
+      "Expression": "IF( __IsStandardLocale, \"mmm\", \"ooo\" )"
     }
   ],
   "RowVariables": [
@@ -60,7 +72,7 @@
     },
     {
       "Name": "__WeekDay",
-      "Expression": "FORMAT ( __Date, \"ddd\"@@GETISO() )"
+      "Expression": "FORMAT ( __Date, __DayFormatString@@GETISO() )"
     },
     {
       "Name": "__FiscalYearNumber",
@@ -131,7 +143,7 @@
     },
     {
       "Name": "Year Month",
-      "Expression": "FORMAT ( __Date, \"mmm yyyy\"@@GETISO() )",
+      "Expression": "FORMAT ( __Date, __MonthFormatString & \" yyyy\"@@GETISO() )",
       "DataType": "String",
       "SortByColumn": "Year Month Number",
       "DataCategory": "Months"
@@ -146,7 +158,7 @@
     },
     {
       "Name": "Month",
-      "Expression": "FORMAT ( __Date, \"mmm\"@@GETISO() )",
+      "Expression": "FORMAT ( __Date, __MonthFormatString@@GETISO() )",
       "DataType": "String",
       "SortByColumn": "Month Number",
       "DataCategory": "MonthOfYear"

--- a/src/Assets/ManageDates/Templates/DateTemplate-02.json
+++ b/src/Assets/ManageDates/Templates/DateTemplate-02.json
@@ -38,6 +38,14 @@
         "0 - First day of fiscal year",
         "1 - Last day of fiscal year"
       ]
+    },
+    {
+      "Name": "__IsStandardLocale",
+      "Expression": "IF ( FORMAT( DATE( 2000, 1, 1 ), \"oooo\"@@GETISO() ) = \"oooo\", TRUE, FALSE )"
+    },
+    {
+      "Name": "__MonthFormatString",
+      "Expression": "IF( __IsStandardLocale, \"mmm\", \"ooo\" )"
     }
   ],
   "RowVariables": [
@@ -133,7 +141,7 @@
         "IF (",
         "    __MonthNumber > 12,",
         "    FORMAT ( __MonthNumber, \"@_M_@00\"@@GETISO() ),",
-        "    FORMAT ( __MonthDate, \"mmm\"@@GETISO() )",
+        "    FORMAT ( __MonthDate, __MonthFormatString@@GETISO() )",
         ")"
       ],
       "DataType": "String",
@@ -154,7 +162,7 @@
         "IF (",
         "    __MonthNumber > 12,",
         "    FORMAT ( __MonthNumber, \"@_M_@00\"@@GETISO() ) & FORMAT ( __YearNumber, \" 0000\"@@GETISO() ),",
-        "    FORMAT ( __MonthDate, \"mmm yyyy\"@@GETISO() )",
+        "    FORMAT ( __MonthDate, __MonthFormatString & \" yyyy\"@@GETISO() )",
         ")"
       ],
       "DataType": "String",
@@ -214,7 +222,7 @@
         "IF (",
         "    __MonthNumber > 12,",
         "    FORMAT ( __MonthNumber, \"@_M_@00\"@@GETISO() ),",
-        "    FORMAT ( __MonthDate, \"mmm\"@@GETISO() )",
+        "    FORMAT ( __MonthDate, __MonthFormatString@@GETISO() )",
         ")"
       ],
       "DataType": "String",

--- a/src/Assets/ManageDates/Templates/DateTemplate-03.json
+++ b/src/Assets/ManageDates/Templates/DateTemplate-03.json
@@ -56,6 +56,18 @@
     {
       "Name": "__OffsetFiscalYearOnOrAfterMonth",
       "Expression": "IF ( __FirstFiscalMonth > 1, __TypeStartFiscalYear, 0 )"
+    },
+    {
+      "Name": "__IsStandardLocale",
+      "Expression": "IF ( FORMAT( DATE( 2000, 1, 1 ), \"oooo\"@@GETISO() ) = \"oooo\", TRUE, FALSE )"
+    },
+    {
+      "Name": "__DayFormatString",
+      "Expression": "IF( __IsStandardLocale, \"ddd\", \"aaa\" )"
+    },
+    {
+      "Name": "__MonthFormatString",
+      "Expression": "IF( __IsStandardLocale, \"mmm\", \"ooo\" )"
     }
   ],
   "RowVariables": [
@@ -118,7 +130,7 @@
     },
     {
       "Name": "__WeekDay",
-      "Expression": "FORMAT ( __Date, \"ddd\"@@GETISO() )"
+      "Expression": "FORMAT ( __Date, __DayFormatString@@GETISO() )"
     },
     {
       "Name": "__HolidayName",
@@ -161,7 +173,7 @@
     },
     {
       "Name": "Year Month",
-      "Expression": "FORMAT ( __Date, \"mmm yyyy\"@@GETISO() )",
+      "Expression": "FORMAT ( __Date, __MonthFormatString & \" yyyy\"@@GETISO() )",
       "DataType": "String",
       "SortByColumn": "Year Month Number",
       "DataCategory": "Months"
@@ -212,7 +224,7 @@
     },
     {
       "Name": "Month",
-      "Expression": "FORMAT ( __Date, \"mmm\"@@GETISO() )",
+      "Expression": "FORMAT ( __Date, __MonthFormatString@@GETISO() )",
       "DataType": "String",
       "SortByColumn": "Fiscal Month Number",
       "DataCategory": "MonthOfYear"

--- a/src/Assets/ManageDates/Templates/DateTemplate-04.json
+++ b/src/Assets/ManageDates/Templates/DateTemplate-04.json
@@ -211,6 +211,18 @@
     {
       "Name": "__FirstWeekReference",
       "Expression": "__FirstSundayReference + __FirstDayOfWeek"
+    },
+    {
+      "Name": "__IsStandardLocale",
+      "Expression": "IF ( FORMAT( DATE( 2000, 1, 1 ), \"oooo\"@@GETISO() ) = \"oooo\", TRUE, FALSE )"
+    },
+    {
+      "Name": "__DayFormatString",
+      "Expression": "IF( __IsStandardLocale, \"ddd\", \"aaa\" )"
+    },
+    {
+      "Name": "__MonthFormatString",
+      "Expression": "IF( __IsStandardLocale, \"mmm\", \"ooo\" )"
     }
   ],
   "RowVariables": [
@@ -264,7 +276,7 @@
     },
     {
       "Name": "__FiscalYearMonth",
-      "Expression": "FORMAT ( __FiscalStartOfMonth + 14, \"@_FM_@ mmm yyyy\"@@GETISO() )"
+      "Expression": "FORMAT ( __FiscalStartOfMonth + 14, \"@_FM_@ \" & __MonthFormatString & \" yyyy\"@@GETISO() )"
     },
     {
       "Name": "__FiscalStartOfMonth",
@@ -298,7 +310,7 @@
     },
     {
       "Name": "__FiscalMonth",
-      "Expression": "FORMAT ( __FiscalStartOfMonth + 14, \"@_FM_@ mmm\"@@GETISO() )"
+      "Expression": "FORMAT ( __FiscalStartOfMonth + 14, \"@_FM_@ \" & __MonthFormatString@@GETISO() )"
     },
     {
       "Name": "__FiscalYearQuarterNumber",
@@ -322,7 +334,7 @@
     },
     {
       "Name": "__WeekDay",
-      "Expression": "FORMAT ( __Date, \"ddd\"@@GETISO() )"
+      "Expression": "FORMAT ( __Date, __DayFormatString@@GETISO() )"
     },
     {
       "Name": "__FiscalDayOfMonthNumber",


### PR DESCRIPTION
Eastern Asian languages - such as Chinese, Korean, Japanese - are affected by a special format strings `aaa` and `ooo` instead of the deault `ddd` and `mmm`