### PR TITLE
Fix spacing char in PBIDesktop.MainWindowTitle suffix

### DIFF
--- a/src/Infrastructure/AppEnvironment.cs
+++ b/src/Infrastructure/AppEnvironment.cs
@@ -39,13 +39,21 @@
         {
             // Different characters are used as a separator in the PBIDesktop window title depending on the current UI culture/localization
             // See https://github.com/sql-bi/Bravo/issues/476
-
             " \u002D Power BI Desktop", // Dash Punctuation - minus hyphen
             " \u2212 Power BI Desktop", // Math Symbol - minus sign
             " \u2011 Power BI Desktop", // Dash Punctuation - non-breaking hyphen
             " \u2013 Power BI Desktop", // Dash Punctuation - en dash
             " \u2014 Power BI Desktop", // Dash Punctuation - em dash
             " \u2015 Power BI Desktop", // Dash Punctuation - horizontal bar
+
+            // The PBIDesktop window title does not always contain the spacing character before and after the separator character
+            // See https://github.com/sql-bi/Bravo/issues/510
+            "\u002DPower BI Desktop", // Dash Punctuation - minus hyphen
+            "\u2212Power BI Desktop", // Math Symbol - minus sign
+            "\u2011Power BI Desktop", // Dash Punctuation - non-breaking hyphen
+            "\u2013Power BI Desktop", // Dash Punctuation - en dash
+            "\u2014Power BI Desktop", // Dash Punctuation - em dash
+            "\u2015Power BI Desktop", // Dash Punctuation - horizontal bar
         };
         public static readonly TimeSpan MSALSignInTimeout = TimeSpan.FromMinutes(5);
         public static readonly Color ThemeColorDark = ColorTranslator.FromHtml("#202020");


### PR DESCRIPTION
The PBIDesktop window title does not always contain the spacing character before and after the separator character