### PR TITLE
Set default DateConfiguration.HolidaysEnabled to FALSE

### DIFF
--- a/src/Models/ManageDates/DateConfiguration.cs
+++ b/src/Models/ManageDates/DateConfiguration.cs
@@ -160,11 +160,11 @@
         public bool HolidaysAvailable { get; set; } = false;
 
         /// <summary>
-        /// Indicates whether the user has enabled this template for deploy
+        /// Indicates whether the user has enabled the creation of the holidays table
         /// </summary>
         [Required]
         [JsonPropertyName("holidaysEnabled")]
-        public bool HolidaysEnabled { get; set; } = true;
+        public bool HolidaysEnabled { get; set; } = false;
 
         [JsonPropertyName("holidaysTableName")]
         public string? HolidaysTableName { get; set; }


### PR DESCRIPTION
The default will be kept at FALSE until the bug that causes Power BI Desktop to crash with certain DAX expressions is fixed