### PR TITLE
Add ConnectionStringHelper.GetConnectionStringProperties

### DIFF
--- a/src/Infrastructure/Helpers/ConnectionStringHelper.cs
+++ b/src/Infrastructure/Helpers/ConnectionStringHelper.cs
@@ -4,10 +4,7 @@
     using Sqlbi.Bravo.Models;
     using System;
     using System.Data.OleDb;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
     using System.Net;
-    using System.Threading;
 
     internal static class ConnectionStringHelper
     {
@@ -143,47 +140,15 @@
             }
         }
 
-        public static string? FindServerName(string? connectionString)
+        public static (string ServerName, string? DatabaseName) GetConnectionStringProperties(string? connectionString)
         {
-            if (TryGetValue(connectionString, DataSourceKey, out var serverName))
-            {
-                return serverName;
-            }
+            var builder = new OleDbConnectionStringBuilder(connectionString);
 
-            return null;
-        }
+            var serverName = builder.DataSource;
+            _ = builder.TryGetValue(InitialCatalogKey, out var initialCatalog);
+            var databaseName = (string?)initialCatalog;
 
-        public static string? FindDatabaseName(string? connectionString)
-        {
-            if (TryGetValue(connectionString, InitialCatalogKey, out var databaseName))
-            {
-                return databaseName;
-            }
-
-            return null;
-        }
-
-        private static bool TryGetValue(string? connectionString, string keyword, [NotNullWhen(true)] out string? value)
-        {
-            value = null;
-
-            OleDbConnectionStringBuilder builder;
-            try
-            {
-                builder = new OleDbConnectionStringBuilder(connectionString);
-            }
-            catch (ArgumentException)
-            {
-                return false;
-            }
-
-            if (builder.TryGetValue(keyword, out var objectValue) && objectValue is string stringValue)
-            {
-                value = stringValue;
-                return true;
-            }
-
-            return false;
+            return (serverName, databaseName);
         }
     }
 }

--- a/src/Models/PBICloudDataset.cs
+++ b/src/Models/PBICloudDataset.cs
@@ -172,8 +172,9 @@
             }
             else if (dataset.IsOnPremModel == true)
             {
-                dataset.ExternalServerName = dataset.ServerName = ConnectionStringHelper.FindServerName(dataset.OnPremModelConnectionString);
-                dataset.ExternalDatabaseName = dataset.DatabaseName = ConnectionStringHelper.FindDatabaseName(dataset.OnPremModelConnectionString);
+                var properties = ConnectionStringHelper.GetConnectionStringProperties(dataset.OnPremModelConnectionString);
+                dataset.ExternalServerName = dataset.ServerName = properties.ServerName;
+                dataset.ExternalDatabaseName = dataset.DatabaseName = properties.DatabaseName;
             }
             else
             {


### PR DESCRIPTION
Use `OleDbConnectionStringBuilder.DataSource` property to get the server name instead of using the hardcoded "Data Source" key.