### PR TITLE
Always return the windowTitle in case the PBID suffix does not exists

### DIFF
--- a/src/Infrastructure/AppEnvironment.cs
+++ b/src/Infrastructure/AppEnvironment.cs
@@ -38,7 +38,8 @@
         public static readonly string PBIDesktopSSASProcessImageName = "msmdsrv.exe";
         public static readonly string[] PBIDesktopMainWindowTitleSuffixes = new string[]
         {
-            // The PBIDesktop main window title is culture-specific
+            // The PBIDesktop main window title is culture-specific.
+            // The suffix is not always present, for example, it is not added when the save/share function in OneDrive/SharePoint is active.
 
             // Different dash characters are used as a separator
             // See https://github.com/sql-bi/Bravo/issues/476

--- a/src/Infrastructure/Extensions/ProcessExtensions.cs
+++ b/src/Infrastructure/Extensions/ProcessExtensions.cs
@@ -77,7 +77,7 @@
             }
         }
 
-        public static string GetMainWindowTitle(this Process process, Func<string, bool>? predicate = default)
+        public static string GetMainWindowTitle(this Process process)
         {
             if (process.MainWindowTitle.Length > 0)
                 return process.MainWindowTitle;
@@ -92,16 +92,10 @@
                     {
                         User32.SendMessage(hWnd, WindowMessage.WM_GETTEXT, builder.Capacity, builder);
 
-                        if (builder.Length > 0)
-                        {
                             var windowTitle = builder.ToString();
-
-                            if (predicate?.Invoke(windowTitle) == true)
+                        if (windowTitle.Length > 0)
                                 return false;
-
-                            builder.Clear();
                         }
-                    }
 
                     return true;
                 },
@@ -116,7 +110,7 @@
 
         public static string? GetPBIDesktopMainWindowTitle(this Process process)
         {
-            var windowTitle = process.GetMainWindowTitle((windowTitle) => windowTitle.IsPBIDesktopMainWindowTitle());
+            var windowTitle = process.GetMainWindowTitle();
 
             if (windowTitle.IsNullOrWhiteSpace())
             {

--- a/src/Infrastructure/Extensions/ProcessExtensions.cs
+++ b/src/Infrastructure/Extensions/ProcessExtensions.cs
@@ -92,10 +92,10 @@
                     {
                         User32.SendMessage(hWnd, WindowMessage.WM_GETTEXT, builder.Capacity, builder);
 
-                            var windowTitle = builder.ToString();
+                        var windowTitle = builder.ToString();
                         if (windowTitle.Length > 0)
-                                return false;
-                        }
+                            return false;
+                    }
 
                     return true;
                 },
@@ -113,10 +113,7 @@
             var windowTitle = process.GetMainWindowTitle();
 
             if (windowTitle.IsNullOrWhiteSpace())
-            {
-                // PBIDesktop process is starting and/or the SSAS instance is not yet started and/or the model is not yet fully loaded
-                return null;
-            }
+                return null; // PBIDesktop process is starting and/or the SSAS instance is not yet started and/or the model is not yet fully loaded
 
             foreach (var suffix in AppEnvironment.PBIDesktopMainWindowTitleSuffixes)
             {
@@ -124,11 +121,11 @@
                 if (index >= 0)
                 {
                     windowTitle = windowTitle[..index];
-                    return windowTitle;
+                    break;
                 }
             }
 
-            return null;
+            return windowTitle;
         }
     }
 }

--- a/src/Infrastructure/Extensions/StringExtensions.cs
+++ b/src/Infrastructure/Extensions/StringExtensions.cs
@@ -30,19 +30,6 @@
             return versionParts;
         }
 
-        public static bool IsPBIDesktopMainWindowTitle(this string windowTitle)
-        {
-            foreach (var suffix in AppEnvironment.PBIDesktopMainWindowTitleSuffixes)
-            {
-                if (windowTitle.EndsWith(suffix))
-                {
-                    return true;
-                }
-            }
-
-            return  false;
-        }
-
         /// <summary>
         /// Convert the old .NET JavaScriptSerializer/DataContractJsonSerializer date format "/Date(1617810719887)/" to <see cref="DateTimeOffset"/>
         /// </summary>

--- a/test/Bravo.Tests/Infrastructure/Extensions/StringExtensionsTests.cs
+++ b/test/Bravo.Tests/Infrastructure/Extensions/StringExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Bravo.Tests.Infrastructure.Extensions
 {
+    using Sqlbi.Bravo.Infrastructure;
     using Sqlbi.Bravo.Infrastructure.Extensions;
     using Sqlbi.Bravo.Models.FormatDax;
     using System;
@@ -124,7 +125,7 @@
                         _output.WriteLine("\t{0} > {1}", unicodeValue, value);
 
                         var formattedTitle = string.Format(/*System.Globalization.CultureInfo.CurrentCulture,*/ value, "Contoso", "Power BI Desktop");
-                        var isSupported = formattedTitle.IsPBIDesktopMainWindowTitle();
+                        var isSupported = AppEnvironment.PBIDesktopMainWindowTitleSuffixes.Any(formattedTitle.EndsWith);
 
                         Assert.True(isSupported, $"Unsupported 'PowerBIWindowTitle' format string in resource file '{file}'");
 


### PR DESCRIPTION
Always return the PBID windowTitle instead of returning null when the suffix ` - Power BI Desktop` is not present.