### PR TITLE
Remove Globalization.UseNls runtime host config

### DIFF
--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -55,11 +55,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Opt-out and use NLS instead of ICU globalization APIs - see https://github.com/sql-bi/Bravo/issues/324#issuecomment-1203624655 -->
-    <RuntimeHostConfigurationOption Include="System.Globalization.UseNls" Value="true" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Dax.Model.Extractor" Version="1.3.3" />
     <PackageReference Include="Dax.Template" Version="0.1.9" />


### PR DESCRIPTION
Removing the globalization APIs opt-out workaround since the related issues have been fixed in TOM libs.
See https://github.com/sql-bi/Bravo/issues/324#issuecomment-1203624655 and https://github.com/sql-bi/Bravo/pull/464