### PR TITLE
Pin AzureSignTool version in yaml pipelines

### DIFF
--- a/.azure/pipelines/build-bravo.yaml
+++ b/.azure/pipelines/build-bravo.yaml
@@ -108,7 +108,7 @@ steps:
   inputs:
     command: 'custom'
     custom: 'tool'
-    arguments: 'update --global azuresigntool'
+    arguments: 'install --global azuresigntool --version 4.0.1' # Pin to latest version compatible with .NET 6.0
 - task: CmdLine@2
   displayName: 'Code signing EXE'
   inputs:

--- a/.azure/pipelines/release-bravo.yaml
+++ b/.azure/pipelines/release-bravo.yaml
@@ -80,7 +80,7 @@ steps:
   inputs:
     command: 'custom'
     custom: 'tool'
-    arguments: 'update --global azuresigntool'
+    arguments: 'install --global azuresigntool --version 4.0.1' # Pin to latest version compatible with .NET 6.0
 - task: CmdLine@2
   displayName: 'Code signing EXE'
   inputs:


### PR DESCRIPTION
 Pinned to latest version compatible with .NET 6.0