### PR TITLE
Fix error when exporting data to XLSX from an empty table

### DIFF
--- a/src/Services/ExportDataService.cs
+++ b/src/Services/ExportDataService.cs
@@ -325,7 +325,9 @@
                 
                 xlsxWriter.BeginWorksheet(worksheetName, splitRow: 1);
                 Export(command, table, xlsxWriter, rowBatchMode: connection.IsDaxFunctionTopNSkipSupported, cancellationToken);
-                xlsxWriter.SetAutoFilter(fromRow: 1, fromColumn: 1, rowCount: table.Rows, columnCount: table.Columns);
+
+                if (table.Rows > 0 && table.Columns > 0)
+                    xlsxWriter.SetAutoFilter(fromRow: 1, fromColumn: 1, rowCount: table.Rows, columnCount: table.Columns);
             }
 
             WriteSummary(job, settings, xlsxWriter);


### PR DESCRIPTION
Fixes an `ArgumentOutOfRangeException` occurring when attempting to export data to XLSX format from an empty table.