### PR TITLE
Fix JP/Greenery Day holiday definition

### DIFF
--- a/src/Assets/ManageDates/Templates/HolidaysDefinition.json
+++ b/src/Assets/ManageDates/Templates/HolidaysDefinition.json
@@ -134,7 +134,6 @@
       "SubstituteHoliday": "FridayIfSaturdayOrMondayIfSunday",
       "ConflictPriority": 100
     },
-
     {
       "IsoCountry": "AT",
       "MonthNumber": 1,
@@ -1971,7 +1970,8 @@
       "OffsetDays": 0,
       "HolidayName": "Greenery Day",
       "SubstituteHoliday": "SubstituteHolidayWithNextNextWorkingDay",
-      "ConflictPriority": 100
+      "ConflictPriority": 100,
+      "FirstYear": 2007
     },
     {
       "IsoCountry": "JP",


### PR DESCRIPTION
In 2007, Greenery Day moved to May 4, and April 29 was changed to Shōwa Day in accordance with a 2005 revision of the law pertaining to public holidays. This fixes an issue where duplicate rows caused the `LOOKUPVALUE` function to fail with the error "A table of multiple values was supplied where a single value was expected" while retrieving the noliday name.