### PR TITLE
Add experimental flag to enable ZIP64 for exporting to Excel

### DIFF
--- a/src/Controllers/ExportDataController.cs
+++ b/src/Controllers/ExportDataController.cs
@@ -106,9 +106,11 @@
         [ProducesDefaultResponseType]
         public IActionResult ExportExcelFile(ExportExcelFromPBIReportRequest request, CancellationToken cancellationToken)
         {
+            var useZip64 = CommonHelper.IsKeyDown(System.Windows.Forms.Keys.ControlKey);
+
             if (WindowDialogHelper.SaveFileDialog(fileName: request.Report!.ReportName, filter: null, defaultExt: "XLSX", out var path, cancellationToken))
             {
-                var job = _exportDataService.ExportExcelFile(request.Report, request.Settings!, path, cancellationToken);
+                var job = _exportDataService.ExportExcelFile(request.Report, request.Settings!, path, useZip64, cancellationToken);
                 return Ok(job);
             }
 
@@ -130,12 +132,14 @@
         [ProducesDefaultResponseType]
         public async Task<IActionResult> ExportExcelFile(ExportExcelFromPBICloudDatasetRequest request, CancellationToken cancellationToken)
         {
+            var useZip64 = CommonHelper.IsKeyDown(System.Windows.Forms.Keys.ControlKey);
+
             if (await _authenticationService.IsPBICloudSignInRequiredAsync(cancellationToken))
                 return Unauthorized();
 
             if (WindowDialogHelper.SaveFileDialog(fileName: request.Dataset!.DisplayName, filter: null, defaultExt: "XLSX", out var path, cancellationToken))
             {
-                var job = _exportDataService.ExportExcelFile(request.Dataset, request.Settings!, path, _authenticationService.PBICloudAuthentication.AccessToken, cancellationToken);
+                var job = _exportDataService.ExportExcelFile(request.Dataset, request.Settings!, path, _authenticationService.PBICloudAuthentication.AccessToken, useZip64, cancellationToken);
                 return Ok(job);
             }
 


### PR DESCRIPTION
Zip64 is an experimental feature in Bravo that must be explicitly enabled by the user and is not enabled by default because it may create a file that Excel or LibreOffice reports as corrupt.