### PR TITLE
Enable DevTools for troubleshooting in non-stable releases

### DIFF
--- a/src/Infrastructure/AppEnvironment.cs
+++ b/src/Infrastructure/AppEnvironment.cs
@@ -126,6 +126,9 @@
 
         public static string ProcessPath { get; }
 
+        // TODO: use custom defined constant to identify a stable release. See PublishMode property and "AdditionalConstants" in csproj
+        public static bool IsStableRelease => Version.TryParse(ApplicationProductVersion, out _);
+
         public static AppPublishMode PublishMode
         {
             get

--- a/src/Infrastructure/AppWindow.cs
+++ b/src/Infrastructure/AppWindow.cs
@@ -137,6 +137,10 @@ window.external = {
             WebView.Source = new Uri(Path.Combine(Environment.CurrentDirectory, "wwwroot\\index.html"));
             // /* ICoreWebView2_3 */ WebView.CoreWebView2.SetVirtualHostNameToFolderMapping("bravo.example", "wwwroot", CoreWebView2HostResourceAccessKind.Allow);
             //WebView.CoreWebView2.Navigate("https://bravo.example/index.html"); // For '.example' see rfc6761
+
+            // Allow users to open the DevTools for troubleshooting; this is only available in non-stable releases
+            if (!AppEnvironment.IsStableRelease && CommonHelper.IsKeyDown(System.Windows.Forms.Keys.ShiftKey))
+                WebView.CoreWebView2.OpenDevToolsWindow();
         }
 
         protected override void WndProc(ref Message message)


### PR DESCRIPTION
Enable the DevTools in non-stable releases when the `Shift` key is pressed