### PR TITLE
Retarget framework from `net6-windows10.0.17763.0` to `net6-windows`

### DIFF
--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6-windows10.0.17763.0</TargetFramework>
-    <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
+    <TargetFramework>net6-windows</TargetFramework>
     <UseWindowsForms>True</UseWindowsForms>
     <ApplicationIcon>Assets\bravo.ico</ApplicationIcon>
     <Company>SQLBI</Company>
@@ -67,6 +66,7 @@
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
+    <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.64.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Management" Version="7.0.0" />

--- a/test/Bravo.Tests/Bravo.Tests.csproj
+++ b/test/Bravo.Tests/Bravo.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
     <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This update addresses a breaking change in the `Microsoft.Identity.Client` library, which has removed support for the `net6.0-windows7.0` binary. To maintain compatibility for desktop applications targeting `net6.0-windows`, the `Microsoft.Identity.Client.Desktop` dependency has been added. This change ensures that authentication using a browser, with the method `WithWindowsEmbeddedBrowserSupport()`, continues to work seamlessly. See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/4468

Additionally, this update allows us to remove the dependency on the `Microsoft.Windows.SDK` framework, which has resulted in a reduction of installed binary sizes.