### PR TITLE
Add support for NET 8

### DIFF
--- a/.azure/pipelines/build-bravo.yaml
+++ b/.azure/pipelines/build-bravo.yaml
@@ -92,6 +92,7 @@ steps:
 - script: dotnet --info
   displayName: dotnet info
 - task: UseDotNet@2
+  displayName: 'Use dotnet SDK'
   inputs:
     packageType: sdk
     useGlobalJson: true

--- a/.azure/pipelines/build-bravo.yaml
+++ b/.azure/pipelines/build-bravo.yaml
@@ -51,6 +51,10 @@ variables:
   installerSourcesDirectory: '$(Build.SourcesDirectory)\installer\wix\src\Bravo'
 
 steps:
+- checkout: self
+  fetchDepth: 1
+  fetchTags: false
+  clean: true
 - task: PowerShell@2
   displayName: 'Set variables'
   inputs:
@@ -82,15 +86,14 @@ steps:
     FileNames: 'src\Bravo.csproj'
     InsertAttributes: true
     FileEncoding: 'auto'
-    WriteBOM: false
+    WriteBOM: true
     VersionNumber: '$(AppVersionNumber)'
+    FileVersionNumber: '$(AppVersionNumber)'
     InformationalVersion: '$(AppVersionInformationalVersion)'
     UpdateBuildNumber: '$(AppBuildNumber)-$(AppVersionNumber)'
     LogLevel: 'verbose'
     FailOnWarning: true
     DisableTelemetry: true
-- script: dotnet --info
-  displayName: dotnet info
 - task: UseDotNet@2
   displayName: 'Use dotnet SDK'
   inputs:

--- a/.azure/pipelines/build-bravo.yaml
+++ b/.azure/pipelines/build-bravo.yaml
@@ -13,30 +13,34 @@ trigger: none
 
 strategy:
   matrix:
-    bravo-net6-x64:
+    bravo-selfcontained-net6:
       arch: 'x64'
       framework: 'net6.0'
       selfcontained: 'true'
       publishmode: 'SELFCONTAINED'
       artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64'
-    bravo-net8-x64:
+      artifactsuffix: ''
+    bravo-selfcontained-net8:
       arch: 'x64'
       framework: 'net8.0'
       selfcontained: 'true'
       publishmode: 'SELFCONTAINED'
-      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).net8-x64'
-    bravo-net6-x64-frameworkdependent:
+      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64'
+      artifactsuffix: '-net8'
+    bravo-frameworkdependent-net6:
       arch: 'x64'
       framework: 'net6.0'
       selfcontained: 'false'
       publishmode: 'FRAMEWORKDEPENDENT'
       artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64-frameworkdependent'
-    bravo-net8-x64-frameworkdependent:
+      artifactsuffix: ''
+    bravo-frameworkdependent-net8:
       arch: 'x64'
       framework: 'net8.0'
       selfcontained: 'false'
       publishmode: 'FRAMEWORKDEPENDENT'
-      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).net8-x64-frameworkdependent'
+      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64-frameworkdependent'
+      artifactsuffix: '-net8'
 
 pool:
   vmImage: 'windows-latest'
@@ -133,7 +137,7 @@ steps:
     # -sice:ICE60 is used to ignore -> warning LGHT1076 : ICE60: The file filE8E88FBC49DC5621FF3FC1B65ADCCB39 is not a Font, and its version is not a companion file reference. It should have a language specified in the Language column.
     # -sice:ICE61 is used to ignore -> warning LGHT1076 : ICE61: This product should remove only older versions of itself. The Maximum version is not less than the current product.
     # -sice:ICE80 is used to ignore -> error   LGHT0204 : ICE80: This 64BitComponent pbitool.json uses 32BitDirectory POWERBIEXTERNALTOOLSFOLDER
-    script: '"%WIX%bin\light.exe" Bravo.wixobj Components.wixobj -ext WixUIExtension.dll -ext WixUtilExtension.dll -dPublishFolder="$(Build.BinariesDirectory)" -cultures:en-us -loc Bravo-en-us.wxl -out "$(Build.ArtifactStagingDirectory)\$(artifact).msi" -spdb -sice:ICE03 -sice:ICE60 -sice:ICE61 -sice:ICE80'
+    script: '"%WIX%bin\light.exe" Bravo.wixobj Components.wixobj -ext WixUIExtension.dll -ext WixUtilExtension.dll -dPublishFolder="$(Build.BinariesDirectory)" -cultures:en-us -loc Bravo-en-us.wxl -out "$(Build.ArtifactStagingDirectory)\$(artifact)$(artifactsuffix).msi" -spdb -sice:ICE03 -sice:ICE60 -sice:ICE61 -sice:ICE80'
     workingDirectory: '$(installerSourcesDirectory)'
     failOnStderr: true
 - task: CmdLine@2
@@ -143,18 +147,18 @@ steps:
     # -sice:ICE60 is used to ignore -> warning LGHT1076 : ICE60: The file filE8E88FBC49DC5621FF3FC1B65ADCCB39 is not a Font, and its version is not a companion file reference. It should have a language specified in the Language column.
     # -sice:ICE61 is used to ignore -> warning LGHT1076 : ICE61: This product should remove only older versions of itself. The Maximum version is not less than the current product.
     # -sice:ICE80 is used to ignore -> error   LGHT0204 : ICE80: This 64BitComponent [...] uses 32BitDirectory [...]
-    script: '"%WIX%bin\light.exe" Bravo-perUser.wixobj Components.wixobj -ext WixUIExtension.dll -ext WixUtilExtension.dll -dPublishFolder="$(Build.BinariesDirectory)" -cultures:en-us -loc Bravo-en-us.wxl -out "$(Build.ArtifactStagingDirectory)\$(artifact)-userinstaller.msi" -spdb -sice:ICE57 -sice:ICE60 -sice:ICE61 -sice:ICE80'
+    script: '"%WIX%bin\light.exe" Bravo-perUser.wixobj Components.wixobj -ext WixUIExtension.dll -ext WixUtilExtension.dll -dPublishFolder="$(Build.BinariesDirectory)" -cultures:en-us -loc Bravo-en-us.wxl -out "$(Build.ArtifactStagingDirectory)\$(artifact)-userinstaller$(artifactsuffix).msi" -spdb -sice:ICE57 -sice:ICE60 -sice:ICE61 -sice:ICE80'
     workingDirectory: '$(installerSourcesDirectory)'
     failOnStderr: true
 - task: CmdLine@2
   displayName: 'Code signing MSI'
   inputs:
-    script: 'AzureSignTool sign -kvu "$(SigningVaultURL)" -kvt "$(SigningTenantId)" -kvi "$(SigningClientId)" -kvs "$(SigningClientSecret)" -kvc "$(SigningCertName)" -tr http://timestamp.digicert.com -v "$(Build.ArtifactStagingDirectory)\$(artifact).msi"'
+    script: 'AzureSignTool sign -kvu "$(SigningVaultURL)" -kvt "$(SigningTenantId)" -kvi "$(SigningClientId)" -kvs "$(SigningClientSecret)" -kvc "$(SigningCertName)" -tr http://timestamp.digicert.com -v "$(Build.ArtifactStagingDirectory)\$(artifact)$(artifactsuffix).msi"'
     failOnStderr: true
 - task: CmdLine@2
   displayName: 'Code signing MSI (perUser)'
   inputs:
-    script: 'AzureSignTool sign -kvu "$(SigningVaultURL)" -kvt "$(SigningTenantId)" -kvi "$(SigningClientId)" -kvs "$(SigningClientSecret)" -kvc "$(SigningCertName)" -tr http://timestamp.digicert.com -v "$(Build.ArtifactStagingDirectory)\$(artifact)-userinstaller.msi"'
+    script: 'AzureSignTool sign -kvu "$(SigningVaultURL)" -kvt "$(SigningTenantId)" -kvi "$(SigningClientId)" -kvs "$(SigningClientSecret)" -kvc "$(SigningCertName)" -tr http://timestamp.digicert.com -v "$(Build.ArtifactStagingDirectory)\$(artifact)-userinstaller$(artifactsuffix).msi"'
     failOnStderr: true
 - task: ArchiveFiles@2
   displayName: 'Portable ZIP archive'
@@ -162,7 +166,7 @@ steps:
     rootFolderOrFile: '$(Build.BinariesDirectory)'
     includeRootFolder: false
     archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/$(artifact)-portable.zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(artifact)-portable$(artifactsuffix).zip'
     replaceExistingArchive: true
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts to DevOps Pipeline'

--- a/.azure/pipelines/build-bravo.yaml
+++ b/.azure/pipelines/build-bravo.yaml
@@ -13,16 +13,30 @@ trigger: none
 
 strategy:
   matrix:
-    bravo-x64:
+    bravo-net6-x64:
       arch: 'x64'
+      framework: 'net6.0'
       selfcontained: 'true'
       publishmode: 'SELFCONTAINED'
       artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64'
-    bravo-x64-frameworkdependent:
+    bravo-net8-x64:
       arch: 'x64'
+      framework: 'net8.0'
+      selfcontained: 'true'
+      publishmode: 'SELFCONTAINED'
+      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).net8-x64'
+    bravo-net6-x64-frameworkdependent:
+      arch: 'x64'
+      framework: 'net6.0'
       selfcontained: 'false'
       publishmode: 'FRAMEWORKDEPENDENT'
       artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64-frameworkdependent'
+    bravo-net8-x64-frameworkdependent:
+      arch: 'x64'
+      framework: 'net8.0'
+      selfcontained: 'false'
+      publishmode: 'FRAMEWORKDEPENDENT'
+      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).net8-x64-frameworkdependent'
 
 pool:
   vmImage: 'windows-latest'
@@ -73,9 +87,13 @@ steps:
     DisableTelemetry: true
 - script: dotnet --info
   displayName: dotnet info
+- task: UseDotNet@2
+  inputs:
+    packageType: sdk
+    useGlobalJson: true
 - script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
   displayName: dotnet restore
-- script: dotnet publish "$(csproj)" --configuration "$(configuration)" --no-restore --runtime "win-$(arch)" --self-contained "$(selfcontained)" --output "$(Build.BinariesDirectory)" --verbosity "${{ parameters.verbosity }}" /p:ContinuousIntegrationBuild="true" /p:AdditionalConstants="$(publishmode)"
+- script: dotnet publish "$(csproj)" --framework "$(framework)-windows" --configuration "$(configuration)" --no-restore --runtime "win-$(arch)" --self-contained "$(selfcontained)" --output "$(Build.BinariesDirectory)" --verbosity "${{ parameters.verbosity }}" /p:ContinuousIntegrationBuild="true" /p:AdditionalConstants="$(publishmode)"
   displayName: dotnet publish
 - script: dotnet tool install --global AzureSignTool
   displayName: dotnet install AzureSignTool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,19 @@ on:
 jobs:
   build-and-test:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        framework: [net6.0-windows, net8.0-windows]
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup .NET
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: setup dotnet
       uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
     - name: dotnet restore
-      run:  dotnet restore
+      run:  dotnet restore Bravo.sln
     - name: dotnet build
-      run:  dotnet build Bravo.sln --configuration Release --no-restore
+      run:  dotnet build Bravo.sln --configuration Release --framework ${{ matrix.framework }} --no-restore
     - name: dotnet test
-      run:  dotnet test Bravo.sln --configuration Release --no-build --verbosity normal
+      run:  dotnet test Bravo.sln --configuration Release --framework ${{ matrix.framework }} --no-build --verbosity normal

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "8.0.400",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -3,55 +3,27 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net6.0-windows;net8.0-windows</TargetFrameworks>
-    <UseWindowsForms>True</UseWindowsForms>
+    <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>Assets\bravo.ico</ApplicationIcon>
-    <Company>SQLBI</Company>
-    <Authors>SQLBI</Authors>
+    <Company>SQLBI Corporation</Company>
     <Product>Bravo for Power BI</Product>
-    <Copyright>SQLBI Corporation</Copyright>
-    <RootNamespace>Sqlbi.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <Copyright>© SQLBI Corporation</Copyright>
+    <AssemblyTitle>Bravo for Power BI</AssemblyTitle>
+    <RootNamespace>Sqlbi.Bravo</RootNamespace>
     <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GenerateDocumentationFile Condition=" '$(Configuration)' != 'Release' ">true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <Configurations>$(Configurations);Debug_wwwroot</Configurations>
+    <!--AnalysisMode>all</AnalysisMode-->
     <AnalysisLevel>latest</AnalysisLevel>
     <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>true</IsPublishable>
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-
-  <Choose>
-    <When Condition=" '$(Configuration)' == 'Debug_wwwroot' ">
-      <PropertyGroup>
-        <DefineConstants>$(AdditionalConstants);DEBUG</DefineConstants>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <DefineConstants>$(AdditionalConstants)</DefineConstants>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-<!--
-  <PropertyGroup>
-    <RestoreSources>$(RestoreSources);./Assets/nupkgs;https://api.nuget.org/v3/index.json</RestoreSources>
-  </PropertyGroup>
--->
-  <PropertyGroup>
-    <!-- Don't change version here -->
-    <Version>0.0.0.999</Version>
-    <InformationalVersion>0.0.0.999-DEV</InformationalVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
@@ -73,24 +45,20 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="wwwroot\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+    </AssemblyAttribute>
     <Reference Include="Antlr4.Runtime">
       <HintPath>Assets\lib\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="TOMWrapper">
       <HintPath>Assets\lib\TOMWrapper.dll</HintPath>
     </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Remove="Scripts\*.json" />
-    <None Include="Scripts\*.json" />
-    <Content Include="Assets\bravo.ico" />
+    <None Include="wwwroot\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <Content Remove="Scripts\**;Assets\**" />
+    <EmbeddedResource Include="Assets\ManageDates\Templates\*.json;Assets\ManageDates\Schemas\*.schema.json" />
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -102,25 +70,42 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Assets\ManageDates\Schemas\*.schema.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Assets\ManageDates\Templates\*.json">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
-
   <!--
-  ** The following custom MSBuild target removes the 'Assets' folder from output after the publish operation.
-  ** 'Assets' folder only contains resource files that have been embedded but are stil published due to a bug (see link below)
-  
-  ** Embedded Resources still copy to output directory even set `CopyToOutputDirectory` to Never
-  ** https://developercommunity.visualstudio.com/t/embedded-resources-still-copy-to-output-directory/1474603
+  Remove unnecessary WPF assemblies from the output (net8 target only)
+  See GH issue https://github.com/dotnet/winforms/issues/2426 and https://github.com/dotnet/sdk/issues/4078
   -->
-  <Target Name="RemoveEmbeddedResourceDirectory" AfterTargets="AfterPublish" Condition=" '$(Configuration)' == 'Release' ">
-    <Message Importance="high" Text="::RemoveEmbeddedResourceDirectory - $(PublishUrl)Assets;$(PublishDir)Assets" />
-    <RemoveDir Directories="$(PublishUrl)Assets;$(PublishDir)Assets" />
+  <Target Name="RemoveWpfAssemblies" AfterTargets="Build;Publish" Condition=" '$(TargetFramework)' == 'net8.0-windows' ">
+    <PropertyGroup>
+      <_OutputPath Condition=" '$(OutputPath)' != '' ">$(OutputPath)</_OutputPath>
+      <_OutputPath Condition=" '$(PublishDir)' != '' ">$(PublishDir)</_OutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <FilesToDelete Include="$(_OutputPath)PresentationCore.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.Aero.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.Aero2.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.AeroLite.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.Classic.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.Luna.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework.Royale.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework-SystemCore.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework-SystemData.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework-SystemDrawing.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework-SystemXml.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationFramework-SystemXmlLinq.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationNative_cor3.dll" />
+      <FilesToDelete Include="$(_OutputPath)PresentationUI.dll" />
+      <FilesToDelete Include="$(_OutputPath)ReachFramework.dll" />
+      <FilesToDelete Include="$(_OutputPath)UIAutomationClient.dll" />
+      <FilesToDelete Include="$(_OutputPath)UIAutomationClientSideProviders.dll" />
+      <FilesToDelete Include="$(_OutputPath)UIAutomationProvider.dll" />
+      <FilesToDelete Include="$(_OutputPath)UIAutomationTypes.dll" />
+      <FilesToDelete Include="$(_OutputPath)WindowsBase.dll" />
+      <FilesToDelete Include="$(_OutputPath)WindowsFormsIntegration.dll" />
+      <FilesToDelete Include="$(_OutputPath)wpfgfx_cor3.dll" />
+    </ItemGroup>
+    <Message Importance="high" Text="::RemoveWpfAssemblies - @(FilesToDelete)" />
+    <Delete Files="@(FilesToDelete)" />
   </Target>
 
   <!-- 
@@ -135,25 +120,15 @@
   -->
 
   <PropertyGroup>
+    <ClientAssetsEnabled Condition="'$(Configuration)' != 'Debug_wwwroot'">true</ClientAssetsEnabled>
     <ClientAssetsDirectory Condition="'$(ClientAssetsDirectory)' == ''">Scripts\</ClientAssetsDirectory>
     <ClientAssetsRestoreInputs Condition="'$(ClientAssetsRestoreInputs)' == ''">$(ClientAssetsDirectory)package-lock.json;$(ClientAssetsDirectory)package.json</ClientAssetsRestoreInputs>
     <ClientAssetsRestoreOutputs Condition="'$(ClientAssetsRestoreOutputs)' == ''">$(ClientAssetsDirectory)node_modules\.package-lock.json</ClientAssetsRestoreOutputs>
-    <ClientAssetsEnabled Condition="'$(Configuration)' != 'Debug_wwwroot'">true</ClientAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>
     <ClientAssetsInputs Include="$(ClientAssetsDirectory)**" Exclude="$(DefaultItemExcludes)" />
   </ItemGroup>
-
-  <!--
-  Target Name="EnsureNodeJsInstalled" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('Scripts\dist') ">
-    <Message Importance="high" Text="::EnsureNodeJsInstalled - retreiving Node.js version ..." />
-    <Exec Command="node - - version" ContinueOnError="true">
-      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
-    </Exec>
-    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project." />
-  </Target
-  -->
 
   <Target Name="ClientAssetsRestore" Condition="'$(ClientAssetsEnabled)' == 'true'" BeforeTargets="Build" Inputs="$(ClientAssetsRestoreInputs)" Outputs="$(ClientAssetsRestoreOutputs)">
     <Message Importance="high" Text="::ClientAssetsRestore - running 'npm install' ..." />

--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6-windows</TargetFramework>
+    <TargetFrameworks>net6.0-windows;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>True</UseWindowsForms>
     <ApplicationIcon>Assets\bravo.ico</ApplicationIcon>
     <Company>SQLBI</Company>

--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.66.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.Management" Version="[6.0.2, 7.0.0)" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.66.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" PrivateAssets="all" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>

--- a/src/Infrastructure/AppWindow.cs
+++ b/src/Infrastructure/AppWindow.cs
@@ -99,7 +99,7 @@ window.external = {
                 //environment.BrowserProcessExited
             }
             await WebView.EnsureCoreWebView2Async(environment);
-#if DEBUG
+#if DEBUG || DEBUG_WWWROOT
             var isDebug = true;
 #else
             var isDebug = false;

--- a/src/Infrastructure/Authentication/AppAuthenticationHandler.cs
+++ b/src/Infrastructure/Authentication/AppAuthenticationHandler.cs
@@ -13,11 +13,17 @@
 
     internal class AppAuthenticationHandler : AuthenticationHandler<AppAuthenticationSchemeOptions>
     {
+#if NET8_0_OR_GREATER
+        public AppAuthenticationHandler(IOptionsMonitor<AppAuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+#else
         public AppAuthenticationHandler(IOptionsMonitor<AppAuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) 
             : base(options, logger, encoder, clock)
         {
         }
-
+#endif
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
             // RemoteIpAddress is null when Kestrel is behind a reverse proxy or the connection is not a TCP connection (like a Unix domain socket)

--- a/src/Infrastructure/Extensions/HostingExtensions.cs
+++ b/src/Infrastructure/Extensions/HostingExtensions.cs
@@ -144,8 +144,11 @@
             services.AddAuthenticationCore();
             //services.AddDataProtection();
             services.AddWebEncoders();
+#if NET8_0_OR_GREATER
+            services.TryAddSingleton(TimeProvider.System);
+#else
             services.TryAddSingleton<ISystemClock, SystemClock>();
-
+#endif
             var builder = new AuthenticationBuilder(services);
             services.Configure<AuthenticationOptions>((options) => options.DefaultScheme = AppEnvironment.ApiAuthenticationSchema);
             builder.AddScheme<AppAuthenticationSchemeOptions, AppAuthenticationHandler>(AppEnvironment.ApiAuthenticationSchema, (options) => options.Validate());

--- a/src/Infrastructure/Helpers/CommonHelper.cs
+++ b/src/Infrastructure/Helpers/CommonHelper.cs
@@ -118,6 +118,7 @@
             bravoUpdate.IsNewerVersion = GetIsNewerVersion(bravoUpdate);
             bravoUpdate.DownloadUrl = GetDownloadUrl(bravoUpdate);
 
+            AppEnvironment.AddDiagnostics(DiagnosticMessageType.Json, name: $"{nameof(CommonHelper)}.{nameof(CheckForUpdateAsync)}", content: JsonSerializer.Serialize(bravoUpdate));
             return bravoUpdate;
 
             static bool GetIsNewerVersion(BravoUpdate bravoUpdate)
@@ -156,6 +157,9 @@
                     downloadFileExtension = ".zip";
                 }
 
+#if NET8_0_OR_GREATER
+                downloadFileNameWithoutExtension += "-net8";
+#endif
                 var newFileName = $"{ downloadFileNameWithoutExtension }{ downloadFileExtension }";
                 var newPath = downloadUri.LocalPath.Replace(downloadFileName, newFileName);
                 var uriBuilder = new UriBuilder(downloadUri)

--- a/test/Bravo.Tests/Bravo.Tests.csproj
+++ b/test/Bravo.Tests/Bravo.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Bravo.Tests/Bravo.Tests.csproj
+++ b/test/Bravo.Tests/Bravo.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6-windows</TargetFramework>
+    <TargetFrameworks>net6.0-windows;net8.0-windows</TargetFrameworks>
     <SupportedOSPlatformVersion>7.0</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Enable multi-targeting in build configuration to support `.NET 8`

- `global.json`: Updated to use .NET SDK version `8.0.400`.
- `Bravo.csproj`: Targeted both `net6-windows` and `net8-windows` frameworks, updated `System.Management` package reference.
