### PR TITLE
Update json-formatter-js dependency to use NPM package

### DIFF
--- a/src/Scripts/package-lock.json
+++ b/src/Scripts/package-lock.json
@@ -15,7 +15,7 @@
         "codemirror": "^5.65.0",
         "draggabilly": "^2.4.1",
         "fast-equals": "^2.0.4",
-        "json-formatter-js": "https://github.com/danieleperilli/json-formatter-js.git",
+        "json-formatter-js": "^2.5.23",
         "sanitize-html": "^2.6.1",
         "split.js": "^1.6.5",
         "tabulator-tables": "^5.4.2",
@@ -1474,8 +1474,9 @@
       }
     },
     "node_modules/json-formatter-js": {
-      "version": "2.3.4",
-      "resolved": "git+ssh://git@github.com/danieleperilli/json-formatter-js.git#89013082d9dfc6e257669e1dee6f6ed6ddc62481",
+      "version": "2.5.23",
+      "resolved": "https://registry.npmjs.org/json-formatter-js/-/json-formatter-js-2.5.23.tgz",
+      "integrity": "sha512-Cbm8wHXjo/C56aCePP1VuKvjxoMEmL7g7Ckss1oWFFlCsvOEEbye1kTeaNNaqba1Cl6YpIOYAnK65pUQ8mDIUQ==",
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -4300,8 +4301,9 @@
       }
     },
     "json-formatter-js": {
-      "version": "git+ssh://git@github.com/danieleperilli/json-formatter-js.git#89013082d9dfc6e257669e1dee6f6ed6ddc62481",
-      "from": "json-formatter-js@https://github.com/danieleperilli/json-formatter-js.git"
+      "version": "2.5.23",
+      "resolved": "https://registry.npmjs.org/json-formatter-js/-/json-formatter-js-2.5.23.tgz",
+      "integrity": "sha512-Cbm8wHXjo/C56aCePP1VuKvjxoMEmL7g7Ckss1oWFFlCsvOEEbye1kTeaNNaqba1Cl6YpIOYAnK65pUQ8mDIUQ=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/src/Scripts/package.json
+++ b/src/Scripts/package.json
@@ -35,7 +35,7 @@
     "codemirror": "^5.65.0",
     "draggabilly": "^2.4.1",
     "fast-equals": "^2.0.4",
-    "json-formatter-js": "https://github.com/danieleperilli/json-formatter-js.git",
+    "json-formatter-js": "^2.5.23",
     "sanitize-html": "^2.6.1",
     "split.js": "^1.6.5",
     "tabulator-tables": "^5.4.2",


### PR DESCRIPTION
Changed the `json-formatter-js` dependency from a GitHub repository link to a specific version (`^2.5.23`) in both `package.json` and `package-lock.json`.