### PR TITLE
Bump VPAX version 1.11.0, Obfuscator 1.2.1

### DIFF
--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -55,12 +55,12 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="Dax.Model.Extractor" Version="1.9.0" />
+    <PackageReference Include="Dax.Model.Extractor" Version="1.11.0" />
     <PackageReference Include="Dax.Template" Version="0.2.1" />
     <PackageReference Include="Dax.Formatter" Version="1.2.0" />
-    <PackageReference Include="Dax.ViewModel" Version="1.9.0" />
-    <PackageReference Include="Dax.Vpax" Version="1.9.0" />
-    <PackageReference Include="Dax.Vpax.Obfuscator" Version="1.1.3" />
+    <PackageReference Include="Dax.ViewModel" Version="1.11.0" />
+    <PackageReference Include="Dax.Vpax" Version="1.11.0" />
+    <PackageReference Include="Dax.Vpax.Obfuscator" Version="1.2.1" />
     <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
     <PackageReference Include="LargeXlsx" Version="1.10.0" />
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />


### PR DESCRIPTION
This pull request updates several NuGet package dependencies in the `Bravo.csproj` file to newer versions.

Dependency upgrades:

* Upgraded `Dax.Model.Extractor` from version 1.9.0 to 1.11.0 for enhanced model extraction capabilities.
* Upgraded `Dax.ViewModel` from version 1.9.0 to 1.11.0 for improved view model support.
* Upgraded `Dax.Vpax` from version 1.9.0 to 1.11.0 for better VPAX file handling.
* Upgraded `Dax.Vpax.Obfuscator` from version 1.1.3 to 1.2.1 for improved obfuscation features.