### PR TITLE
Fix crash when connecting to a local PBI Desktop

### DIFF
--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.66.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.Management" Version="[6.0.2, 7.0.0)" />
+    <PackageReference Include="System.Management" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes a bug introduced in version 1.0.10 that causes the application to crash and close when attempting to connect to a local PBI Desktop model.