### PR TITLE
Remove `ToProtectedString` and `ToUnprotectedString`

### DIFF
--- a/src/Infrastructure/Helpers/ConnectionStringHelper.cs
+++ b/src/Infrastructure/Helpers/ConnectionStringHelper.cs
@@ -45,7 +45,7 @@
                 { ApplicationNameKey, AppEnvironment.ApplicationInstanceUniqueName }
             };
 
-            return builder.ConnectionString.ToProtectedString();
+            return builder.ConnectionString;
         }
 
         public static string BuildFor(PBIDesktopReport report)
@@ -63,7 +63,7 @@
                 { ApplicationNameKey, AppEnvironment.ApplicationInstanceUniqueName }
             };
 
-            return builder.ConnectionString.ToProtectedString();
+            return builder.ConnectionString;
         }
 
         public static string BuildFor(PBICloudDataset dataset, string accessToken)
@@ -102,15 +102,14 @@
                 };
                 var serverName = serverNameBuilder.Uri.AbsoluteUri;
                 var databaseName = dataset.ExternalDatabaseName;
-                var connectionString = Build(serverName, databaseName, accessToken, dataset.IdentityProvider);
 
-                return connectionString.ToProtectedString();
+                return Build(serverName, databaseName, accessToken, dataset.IdentityProvider);
             }
             else if (dataset.IsOnPremModel == true)
             {
                 BravoUnexpectedException.ThrowIfNull(dataset.OnPremModelConnectionString);
 
-                return dataset.OnPremModelConnectionString.ToProtectedString();
+                return dataset.OnPremModelConnectionString;
             }
             else
             {
@@ -121,9 +120,8 @@
 
                 var serverName = dataset.ExternalServerName;
                 var databaseName = dataset.ExternalDatabaseName;
-                var connectionString = Build(serverName, databaseName, accessToken, dataset.IdentityProvider);
 
-                return connectionString.ToProtectedString();
+                return Build(serverName, databaseName, accessToken, dataset.IdentityProvider);
             }
 
             static string Build(string serverName, string databaseName, string accessToken, string identityProvider)

--- a/src/Infrastructure/Security/Cryptography.cs
+++ b/src/Infrastructure/Security/Cryptography.cs
@@ -85,24 +85,6 @@
     {
         public static string? ToSHA256Hash(this string value) => Cryptography.SHA256Hash(value);
 
-        public static string ToProtectedString(this string unprotectedString)
-        {
-            var unprotectedBytes = Encoding.Unicode.GetBytes(unprotectedString);
-            var protectedBytes = Cryptography.Protect(unprotectedBytes);
-            var protectedString = Convert.ToBase64String(protectedBytes);
-
-            return protectedString;
-        }
-
-        public static string ToUnprotectedString(this string protectedString)
-        {
-            var protectedBytes = Convert.FromBase64String(protectedString);
-            var unprotectedBytes = Cryptography.Unprotect(protectedBytes);
-            var unprotectedString = Encoding.Unicode.GetString(unprotectedBytes);
-
-            return unprotectedString;
-        }
-
         public static string ToProtectedString(this SecureString secureString)
         {
             var unsecuredChars = new char[secureString.Length];

--- a/src/Infrastructure/Services/ConnectionWrapper.cs
+++ b/src/Infrastructure/Services/ConnectionWrapper.cs
@@ -18,7 +18,7 @@
             _connectionString = connectionString;
 
             Server = new TOM.Server();
-            ProcessHelper.RunOnUISynchronizationContext(() => Server.Connect(connectionString.ToUnprotectedString()));
+            ProcessHelper.RunOnUISynchronizationContext(() => Server.Connect(connectionString));
             Database = findById ? Server.Databases.Find(databaseIdOrName) : Server.Databases.FindByName(databaseIdOrName);
 
             if (Database is null)
@@ -49,7 +49,7 @@
 
         public AdomdConnection CreateAdomdConnection(bool open = true)
         {
-            var connection = new AdomdConnection(_connectionString.ToUnprotectedString());
+            var connection = new AdomdConnection(_connectionString);
 
             if (open)
             {
@@ -91,7 +91,7 @@
     {
         private AdomdConnectionWrapper(string connectionString, string databaseName)
         {
-            Connection = new AdomdConnection(connectionString.ToUnprotectedString());
+            Connection = new AdomdConnection(connectionString);
             ProcessHelper.RunOnUISynchronizationContext(() => Connection.Open());
             Connection.ChangeDatabase(databaseName);
 

--- a/src/Models/PBIDesktopReport.cs
+++ b/src/Models/PBIDesktopReport.cs
@@ -128,7 +128,7 @@
                 var connectionString = ConnectionStringHelper.BuildFor(ssasConnection.EndPoint);
                 try
                 {
-                    server.Connect(connectionString.ToUnprotectedString());
+                    server.Connect(connectionString);
                     compatibilityMode = server.CompatibilityMode;
                 }
                 catch (Exception ex)

--- a/test/Bravo.Tests/Infrastructure/Security/CryptographyExtensionsTests.cs
+++ b/test/Bravo.Tests/Infrastructure/Security/CryptographyExtensionsTests.cs
@@ -32,18 +32,5 @@
 
             Assert.Equal(expected, actual);
         }
-
-        [Theory]
-        [InlineData("MySecret^ìfd56486-+{6 ♠ ⌂¿EFE==")]
-        [InlineData("AsDfJkIl123456")]
-        [InlineData("123==")]
-        [InlineData("")]
-        public void ToProtectedStringToUnprotectedString_SimpleTest(string expected)
-        {
-            var protectedString = expected.ToProtectedString();
-            var actual = protectedString.ToUnprotectedString();
-
-            Assert.Equal(expected, actual);
-        }
     }
 }


### PR DESCRIPTION
Telemetry shows `CryptographicException` errors occurring with these methods. Since connection strings are not persisted or saved anywhere and only remain in memory, encryption is not necessary. If encryption support is needed in the future, we will consider using ASP.NET Core Data Protection instead of DPAPI to avoid these transient errors.