### PR TITLE
Fix `Group By Table` button not visible for empty models

### DIFF
--- a/src/Scripts/model/doc.ts
+++ b/src/Scripts/model/doc.ts
@@ -45,7 +45,7 @@ export class Doc {
     orphan: boolean;
 
     get empty(): boolean {
-        return (!this.model || !this.model.size || (!this.model.columns.length && !this.measures.length));
+        return (!this.model || (!this.model.columns.length && !this.measures.length));
     }
 
     constructor(name: string, type: DocType, sourceData: File | PBICloudDataset | PBIDesktopReport) {


### PR DESCRIPTION
Models with zero size but with columns/tables were treated as empty, hiding the Group By Table button. Fixed by updating the empty check to ignore model size.