### PR TITLE
Use SemVer as the single versioning scheme

### DIFF
--- a/.azure/pipelines/build-bravo.yaml
+++ b/.azure/pipelines/build-bravo.yaml
@@ -16,11 +16,11 @@ strategy:
     bravo-x64:
       arch: 'x64'
       selfcontained: 'true'
-      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64'
+      artifactSuffix: 'x64'
     bravo-x64-frameworkdependent:
       arch: 'x64'
       selfcontained: 'false'
-      artifact: 'Bravo.$(AppVersionMajor).$(AppVersionMinor).$(AppVersionPatch).x64-frameworkdependent'
+      artifactSuffix: 'x64-frameworkdependent'
 
 pool:
   vmImage: 'windows-latest'
@@ -31,52 +31,28 @@ variables:
   installerSourcesDirectory: '$(Build.SourcesDirectory)\installer\wix\src\Bravo'
 
 steps:
-- task: PowerShell@2
-  displayName: 'Set variables'
+- checkout: self
+  fetchDepth: 0 # Required for NBGV
+  fetchTags: false
+  clean: true
+- task: UseDotNet@2
+  displayName: Setup DotNet
   inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "Computing variables..."
-      $url = "$(system.CollectionUri)$(system.TeamProjectId)/_apis/build/builds/$(Build.BuildId)?api-version=5.1"
-      $build = Invoke-RestMethod -Uri $url -Headers @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" } -Method Get
-      $buildTime = [datetime]$build.startTime
-      $buildNumberRevision = $build.buildNumberRevision
-      $midnightTime = (Get-Date -Year $buildTime.Year -Month $buildTime.Month -Day $buildTime.Day -Hour 0 -Minute 0 -Second 0 -Millisecond 0)
-      # Build Number - number of days since 2000-01-01 (same algorithm as msbuild)
-      $versionBuild = (New-TimeSpan –Start ([datetime]"2000-01-01") –End $buildTime).Days
-      # Revision - number of seconds since midnight divided by 2 (same algorithm as msbuild)
-      $versionRevision = [math]::Round((New-TimeSpan –Start $midnightTime –End $buildTime).TotalSeconds / 2)
-      $buildNumber = '{0:yyyyMMdd}.{1}' -f $buildTime, $buildNumberRevision
-      $versionNumber = '{0}.{1}.{2}.{3}' -f "$(AppVersionMajor)", "$(AppVersionMinor)", $versionBuild, $versionRevision
-      Write-Host "Setting output variables..."
-      Write-Host "##vso[task.setvariable variable=AppBuildNumber;]$buildNumber"
-      Write-Host "##vso[task.setvariable variable=AppVersionNumber;]$versionNumber"
-      Write-Host "BuildNumber is $buildNumber"
-      Write-Host "VersionNumber is $versionNumber"
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-- task: Assembly-Info-NetCore@3
-  displayName: 'Update AssemblyInfo'
-  inputs:
-    Path: '$(Build.SourcesDirectory)'
-    FileNames: 'src\Bravo.csproj'
-    InsertAttributes: true
-    FileEncoding: 'auto'
-    WriteBOM: false
-    VersionNumber: '$(AppVersionNumber)'
-    InformationalVersion: '$(AppVersionInformationalVersion)'
-    UpdateBuildNumber: '$(AppBuildNumber)-$(AppVersionNumber)'
-    LogLevel: 'verbose'
-    FailOnWarning: true
-    DisableTelemetry: true
-- script: dotnet --info
-  displayName: dotnet info
+    packageType: sdk
+    useGlobalJson: true
+- script: nbgv cloud --all-vars
+  displayName: Setup NBGV
+- script: dotnet tool install --global AzureSignTool
+  displayName: Setup AzureSignTool
+- bash: |
+    artifact="Bravo.$(NBGV_SimpleVersion).$(artifactSuffix)"
+    echo "##vso[task.setvariable variable=artifact]$artifact"
+    echo "Artifact name: $artifact"
+  displayName: 'Compute variables'
 - script: dotnet restore "$(csproj)" --runtime "win-$(arch)" --verbosity "${{ parameters.verbosity }}"
   displayName: dotnet restore
 - script: dotnet publish "$(csproj)" --configuration "$(configuration)" --no-restore --runtime "win-$(arch)" --self-contained "$(selfcontained)" --output "$(Build.BinariesDirectory)" --verbosity "${{ parameters.verbosity }}" /p:ContinuousIntegrationBuild="true"
   displayName: dotnet publish
-- script: dotnet tool install --global AzureSignTool
-  displayName: dotnet install AzureSignTool
 - task: CmdLine@2
   displayName: 'Code signing EXE'
   inputs:
@@ -97,13 +73,13 @@ steps:
 - task: CmdLine@2
   displayName: 'WiX compile app'
   inputs:
-    script: '"%WIX%bin\candle.exe" Bravo.wxs -dPublishFolder="$(Build.BinariesDirectory)" -dVersion="$(AppVersionInformationalVersion)" -arch "$(arch)"'
+    script: '"%WIX%bin\candle.exe" Bravo.wxs -dPublishFolder="$(Build.BinariesDirectory)" -dVersion="$(NBGV_SimpleVersion)" -arch "$(arch)"'
     workingDirectory: '$(installerSourcesDirectory)'
     failOnStderr: true
 - task: CmdLine@2
   displayName: 'WiX compile app (perUser)'
   inputs:
-    script: '"%WIX%bin\candle.exe" Bravo-perUser.wxs -dPublishFolder="$(Build.BinariesDirectory)" -dVersion="$(AppVersionInformationalVersion)" -arch "$(arch)"'
+    script: '"%WIX%bin\candle.exe" Bravo-perUser.wxs -dPublishFolder="$(Build.BinariesDirectory)" -dVersion="$(NBGV_SimpleVersion)" -arch "$(arch)"'
     workingDirectory: '$(installerSourcesDirectory)'
     failOnStderr: true
 - task: CmdLine@2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: setup dotnet SDK
       uses: actions/setup-dotnet@v4
       with:

--- a/Bravo.sln
+++ b/Bravo.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32014.148
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11903.348 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bravo", "src\Bravo.csproj", "{3D49664E-E100-4EFF-A709-A59D03F4663E}"
 EndProject

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "10.0.300",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
   }

--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -21,7 +21,6 @@
     <IsPublishable>true</IsPublishable>
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
-    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 
@@ -32,12 +31,6 @@
 
   <PropertyGroup Condition="'$(SelfContained)' == 'true'">
     <DefineConstants>$(DefineConstants);PUBLISHMODE_SELFCONTAINED</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <!-- Don't change version here -->
-    <Version>0.0.0.999</Version>
-    <InformationalVersion>0.0.0.999-DEV</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -59,6 +52,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" />
     <PackageReference Include="Microsoft.Identity.Client.Desktop" Version="4.73.1" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" PrivateAssets="all" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Management" Version="7.0.0" />

--- a/src/Infrastructure/AppEnvironment.cs
+++ b/src/Infrastructure/AppEnvironment.cs
@@ -83,13 +83,8 @@
             ProcessId = Environment.ProcessId;
             SessionId = currentProcess.SessionId;
             ProcessPath = Environment.ProcessPath!;
-            
-            VersionInfo = FileVersionInfo.GetVersionInfo(ProcessPath);
-            BravoUnexpectedException.ThrowIfNull(VersionInfo.FileVersion);
-            ApplicationFileVersion = VersionInfo.FileVersion;
-            BravoUnexpectedException.ThrowIfNull(VersionInfo.ProductVersion);
-            ApplicationProductVersion = VersionInfo.ProductVersion;
 
+            VersionInfo = new AppVersionInfo();
             ApplicationDataPath = Path.Combine(Environment.GetFolderPath(DeploymentMode == AppDeploymentMode.Packaged ? Environment.SpecialFolder.UserProfile : Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), ApplicationName);
             ApplicationTempPath = Path.Combine(ApplicationDataPath, ".temp");
             UserSettingsFilePath = Path.Combine(ApplicationDataPath, "usersettings.json");
@@ -111,9 +106,6 @@
         public static int ProcessId { get; }
 
         public static string ProcessPath { get; }
-
-        // TODO: use custom defined constant to identify a stable release. See PublishMode property and "AdditionalConstants" in csproj
-        public static bool IsStableRelease => Version.TryParse(ApplicationProductVersion, out _);
 
         public static AppPublishMode PublishMode
         {
@@ -147,9 +139,7 @@
             }
         }
 
-        public static string ApplicationFileVersion { get; }
-
-        public static string ApplicationProductVersion { get; }
+        public static AppVersionInfo VersionInfo { get; }
 
         public static JsonSerializerOptions DefaultJsonOptions { get; }
 
@@ -160,8 +150,6 @@
         public static string UserSettingsFilePath { get; }
 
         public static string MsalTokenCacheFilePath { get; }
-
-        public static FileVersionInfo VersionInfo { get; }
 
         public static string? WebView2VersionInfo { get; }
 
@@ -206,12 +194,10 @@
                 //
                 ApplicationPublishMode = PublishMode.ToString(),
                 ApplicationDeploymentMode = DeploymentMode.ToString(),
-                ApplicationFileVersion,
-                ApplicationProductVersion,
+                ApplicationVersion = VersionInfo.InformationalVersion,
                 ApplicationDataPath,
                 ApplicationTempPath,
                 ApplicationUserSettingsFilePath = UserSettingsFilePath,
-                //ApplicationFileVersionInfo = VersionInfo,
             };
 
             AddDiagnostics(DiagnosticMessageType.Json, name: $"{nameof(AppEnvironment)}.EnvironmentInfo", content: JsonSerializer.Serialize(info));

--- a/src/Infrastructure/AppVersionInfo.cs
+++ b/src/Infrastructure/AppVersionInfo.cs
@@ -1,0 +1,36 @@
+namespace Sqlbi.Bravo.Infrastructure
+{
+    /// <summary>
+    /// Exposes the application version, stamped at build time by Nerdbank.GitVersioning from version.json.
+    /// </summary>
+    internal sealed class AppVersionInfo
+    {
+        public AppVersionInfo()
+        {
+            var build = ThisAssembly.AssemblyFileVersion;
+
+            Build = build;
+            Version = System.Version.Parse(build).ToString(3);
+            InformationalVersion = ThisAssembly.AssemblyInformationalVersion;
+        }
+
+        /// <summary>
+        /// Gets the full four-part assembly file version <c>Major.Minor.Patch.Height</c>, where the fourth field is the
+        /// git-height build counter. Intended for diagnostics only (e.g. telemetry) - never used for update comparisons
+        /// or shown to users; use <see cref="Version"/> instead.
+        /// </summary>
+        public string Build { get; }
+
+        /// <summary>
+        /// Gets the three-part Semantic Version <c>Major.Minor.Patch</c>. This is the canonical application version:
+        /// shown to users and used to compare versions when checking for updates.
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// Gets the informational version: the version with build metadata (the git commit id) appended,
+        /// e.g. <c>1.2.3.45+0a1b2c3d4e</c>. Intended for diagnostics.
+        /// </summary>
+        public string InformationalVersion { get; }
+    }
+}

--- a/src/Infrastructure/AppWindow.cs
+++ b/src/Infrastructure/AppWindow.cs
@@ -134,9 +134,7 @@ window.external = {
             /* ICoreWebView2_3  */ WebView.CoreWebView2.SetVirtualHostNameToFolderMapping("bravo.example", "wwwroot", CoreWebView2HostResourceAccessKind.Allow);
             /* ICoreWebView2    */ WebView.CoreWebView2.Navigate("https://bravo.example/index.html");
 
-            // Allow users to open the DevTools for troubleshooting; this is only available in non-stable releases
-            if (!AppEnvironment.IsStableRelease && CommonHelper.IsKeyDown(System.Windows.Forms.Keys.ShiftKey))
-                WebView.CoreWebView2.OpenDevToolsWindow();
+            // TODO: Consider allowing users to open DevTools for troubleshooting (e.g. by pressing F12 or via a context menu)
         }
 
         protected override void WndProc(ref Message message)
@@ -307,8 +305,7 @@ window.external = {
 #endif
                 address = _serverAddressProvider.GetListeningAddress(),
                 token = AppEnvironment.ApiAuthenticationToken,
-                version = AppEnvironment.ApplicationProductVersion,
-                build = AppEnvironment.ApplicationFileVersion,
+                version = AppEnvironment.VersionInfo.Version,
                 options = BravoOptions.CreateFromUserPreferences(),
                 policies = BravoPolicies.Current,
                 culture = new

--- a/src/Infrastructure/Extensions/StringExtensions.cs
+++ b/src/Infrastructure/Extensions/StringExtensions.cs
@@ -17,17 +17,7 @@
 
         public static string AppendApplicationVersion(this string value)
         {
-            var valueAndVersion = $"{value} - v{GetVersionParts(AppEnvironment.ApplicationProductVersion, parts: 4)}";
-            return valueAndVersion;
-        }
-
-        public static string GetVersionParts(this string? version, int parts)
-        {
-            if  (version.IsNullOrWhiteSpace())
-                return string.Empty;
-
-            var versionParts = string.Join('-', version.Split('-').Take(parts));
-            return versionParts;
+            return $"{value} - v{AppEnvironment.VersionInfo.Version}";
         }
 
         /// <summary>

--- a/src/Infrastructure/Helpers/CommonHelper.cs
+++ b/src/Infrastructure/Helpers/CommonHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace Sqlbi.Bravo.Infrastructure.Helpers
 {
-    using Sqlbi.Bravo.Infrastructure.Configuration;
     using Sqlbi.Bravo.Infrastructure.Configuration.Settings;
     using Sqlbi.Bravo.Infrastructure.Extensions;
     using Sqlbi.Bravo.Infrastructure.Windows.Interop;
@@ -104,36 +103,31 @@
             var requestUri = $"https://bravorelease.blob.core.windows.net/{ channelPath }/currentversion.json?nocache={ DateTimeOffset.Now.ToUnixTimeSeconds() }";
             var json = await httpClient.GetStringAsync(requestUri, cancellationToken).ConfigureAwait(false);
 
-            using var document = JsonDocument.Parse(json);
+            AppEnvironment.AddDiagnostics(DiagnosticMessageType.Json, name: $"{nameof(CommonHelper)}.{nameof(CheckForUpdateAsync)}", content: json);
 
-            var bravoUpdate = new BravoUpdate
+            using var document = JsonDocument.Parse(json);
+            var rootElement = document.RootElement;
+
+            var version = Version.Parse(rootElement.GetProperty("version").GetString()!)
+                .ToString(3); // Versioning is SemVer-based: discard a 4th (build) digit if present
+            var isNewerVersion = Version.Parse(version) > Version.Parse(AppEnvironment.VersionInfo.Version);
+            var downloadUrl = GetDownloadUrl(rootElement.GetProperty("download").GetString()!);
+            var changelogUrl = rootElement.GetProperty("changelog").GetString()!;
+
+            return new BravoUpdate
             {
                 UpdateChannel = updateChannel,
-                InstalledVersion = AppEnvironment.ApplicationFileVersion,
-                CurrentVersion = document.RootElement.GetProperty("version").GetString(),
-                DownloadUrl = document.RootElement.GetProperty("download").GetString(),
-                ChangelogUrl = document.RootElement.GetProperty("changelog").GetString(),
+                IsNewerVersion = isNewerVersion,
+                Version = version,
+                DownloadUrl = downloadUrl,
+                ChangelogUrl = changelogUrl,
             };
 
-            bravoUpdate.IsNewerVersion = GetIsNewerVersion(bravoUpdate);
-            bravoUpdate.DownloadUrl = GetDownloadUrl(bravoUpdate);
-
-            AppEnvironment.AddDiagnostics(DiagnosticMessageType.Json, name: $"{nameof(CommonHelper)}.{nameof(CheckForUpdateAsync)}", content: JsonSerializer.Serialize(bravoUpdate));
-            return bravoUpdate;
-
-            static bool GetIsNewerVersion(BravoUpdate bravoUpdate)
-            {
-                var installedVersion = Version.Parse(bravoUpdate.InstalledVersion!);
-                var currentVersion = Version.Parse(bravoUpdate.CurrentVersion!);
-
-                return currentVersion > installedVersion;
-            }
-
-            static string GetDownloadUrl(BravoUpdate bravoUpdate)
+            static string GetDownloadUrl(string downloadUrl)
             {
                 BravoUnexpectedException.Assert(AppEnvironment.DeploymentMode != AppDeploymentMode.Packaged);
 
-                var downloadUri = new Uri(bravoUpdate.DownloadUrl!, UriKind.Absolute);
+                var downloadUri = new Uri(downloadUrl, UriKind.Absolute);
                 var downloadFileNameWithoutExtension = Path.GetFileNameWithoutExtension(downloadUri.LocalPath);
                 var downloadFileExtension = Path.GetExtension(downloadUri.LocalPath);
                 var downloadFileName = Path.GetFileName(downloadUri.LocalPath);

--- a/src/Infrastructure/Helpers/VpaxHelper.cs
+++ b/src/Infrastructure/Helpers/VpaxHelper.cs
@@ -56,12 +56,12 @@
         {
             var server = connectionWrapper.Server;
             var database = connectionWrapper.Database;
-            var daxModel = TomExtractor.GetDaxModel(database.Model, extractorApp: AppEnvironment.ApplicationName, extractorVersion: AppEnvironment.ApplicationProductVersion);
+            var daxModel = TomExtractor.GetDaxModel(database.Model, extractorApp: AppEnvironment.ApplicationName, extractorVersion: AppEnvironment.VersionInfo.Version);
 
             using var connection = connectionWrapper.CreateAdomdConnection(open: false);
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                DmvExtractor.PopulateFromDmv(daxModel, connection, server.Name, database.Name, extractorApp: AppEnvironment.ApplicationName, extractorVersion: AppEnvironment.ApplicationProductVersion);
+                DmvExtractor.PopulateFromDmv(daxModel, connection, server.Name, database.Name, extractorApp: AppEnvironment.ApplicationName, extractorVersion: AppEnvironment.VersionInfo.Version);
 
                 if (statisticsEnabled)
                 {
@@ -76,7 +76,7 @@
                     if (analyzeDirectLake > DirectLakeExtractionMode.ResidentOnly && daxModel.HasDirectLakePartitions())
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        DmvExtractor.PopulateFromDmv(daxModel, connection, server.Name, database.Name, extractorApp: AppEnvironment.ApplicationName, extractorVersion: AppEnvironment.ApplicationProductVersion);
+                        DmvExtractor.PopulateFromDmv(daxModel, connection, server.Name, database.Name, extractorApp: AppEnvironment.ApplicationName, extractorVersion: AppEnvironment.VersionInfo.Version);
                     }
                 }
             }

--- a/src/Infrastructure/Telemetry/TelemetrySessionInfo.cs
+++ b/src/Infrastructure/Telemetry/TelemetrySessionInfo.cs
@@ -7,7 +7,7 @@ internal static class TelemetrySessionInfo
     /// <summary>See <see cref="Microsoft.ApplicationInsights.Extensibility.Implementation.Endpoints.Constants"/></summary>
     public static Uri DefaultIngestionEndpoint { get; } = new Uri("https://dc.services.visualstudio.com/", UriKind.Absolute);
     public static string ConnectionString { get; } = "InstrumentationKey=47a8970c-6293-408a-9cce-5b7b311574d3";
-    public static string ComponentVersion { get; } = AppEnvironment.ApplicationProductVersion;
+    public static string ComponentVersion { get; } = AppEnvironment.VersionInfo.Version;
     public static string DeviceOperatingSystem { get; } = Environment.OSVersion.ToString();
     public static string SessionId { get; } = Guid.NewGuid().ToString();
     public static string UserId { get; } = $"{Environment.MachineName}\\{Environment.UserName}".ToSHA256Hash();
@@ -15,8 +15,8 @@ internal static class TelemetrySessionInfo
     public static IReadOnlyDictionary<string, string> GlobalProperties { get; } = new Dictionary<string, string>
     {
         { "ProductName", AppEnvironment.ApplicationName },
-        { "Version", AppEnvironment.ApplicationProductVersion },
-        { "Build", AppEnvironment.ApplicationFileVersion },
+        { "Version", AppEnvironment.VersionInfo.Version },
+        { "Build", AppEnvironment.VersionInfo.Build },
         { "PublishMode", AppEnvironment.PublishMode.ToString() },
         { "InstallScope", AppEnvironment.DeploymentMode.ToString() },
         { "WebView2Version", AppEnvironment.WebView2VersionInfo ?? string.Empty },

--- a/src/Models/BravoUpdate.cs
+++ b/src/Models/BravoUpdate.cs
@@ -9,9 +9,7 @@
 
         bool IsNewerVersion { get; set; }
 
-        string? CurrentVersion { get; set; }
-
-        string? InstalledVersion { get; set; }
+        string? Version { get; set; }
 
         string? DownloadUrl { get; set; }
 
@@ -26,11 +24,8 @@
         [JsonPropertyName("isNewerVersion")]
         public bool IsNewerVersion { get; set; } = false;
 
-        [JsonPropertyName("currentVersion")]
-        public string? CurrentVersion { get; set; }
-
-        [JsonPropertyName("installedVersion")]
-        public string? InstalledVersion { get; set; }
+        [JsonPropertyName("version")]
+        public string? Version { get; set; }
 
         [JsonPropertyName("downloadUrl")]
         public string? DownloadUrl { get; set; }

--- a/src/Scripts/@types/global.d.ts
+++ b/src/Scripts/@types/global.d.ts
@@ -8,7 +8,6 @@ declare global {
         debug?: boolean,
         address: string
         version: string,
-        build: string
         options: Options,
         policies?: Dic<PolicyStatus>,
         token?: string,

--- a/src/Scripts/controllers/app.ts
+++ b/src/Scripts/controllers/app.ts
@@ -30,7 +30,6 @@ import { DialogResponse } from '../view/dialog';
 
 export interface AppVersionInfo {
     version: string
-    build?: string
     downloadUrl?: string
     changelogUrl?: string
 }
@@ -42,7 +41,7 @@ export class AppVersion {
     }
 
     toString() {
-        return `${this.info.version}${this.info.build ? ` (${this.info.build})` : ""}`;
+        return this.info.version;
     }
 }
 export class App {
@@ -429,7 +428,7 @@ export class App {
                 let newVersion = null;
                 if (data.updateChannel == optionsController.options.updateChannel && data.isNewerVersion) {
                     newVersion = new AppVersion({
-                        version: data.currentVersion,
+                        version: data.version,
                         downloadUrl: data.downloadUrl,
                         changelogUrl: data.changelogUrl
                     });

--- a/src/Scripts/controllers/debug.ts
+++ b/src/Scripts/controllers/debug.ts
@@ -37,8 +37,7 @@ export class Debug {
             globalThis.CONFIG = {
                 debug: true,
                 address: "http://localhost",
-                version: "0.0.0-0.1",
-                build: "0.1",
+                version: "0.0.0",
                 options: null,
                 token: "",
                 culture: {

--- a/src/Scripts/controllers/host.ts
+++ b/src/Scripts/controllers/host.ts
@@ -170,12 +170,11 @@ export interface CreateDateTemplateRequest {
 
 export interface BravoUpdate {
     updateChannel: UpdateChannelType
-    currentVersion?: string
-    installedVersion?: string
+    version?: string
     downloadUrl?: string
     changelogUrl?: string
     isNewerVersion: boolean
-} 
+}
 
 export interface ApiLogSettings {
     messageLevel?: DiagnosticLevelType // Minimum diagnostic level required to log the message

--- a/src/Scripts/main.ts
+++ b/src/Scripts/main.ts
@@ -31,8 +31,7 @@ let pbiDesktop = new PBIDesktop();
 let notificationCenter = new NotifyCenter();
 
 let app = new App(new AppVersion({
-    version: CONFIG.version,
-    build: CONFIG.build
+    version: CONFIG.version
 }));
 
 export { debug, host, optionsController, themeController, auth, telemetry, pbiDesktop, notificationCenter, logger, app };

--- a/src/Scripts/view/options-dialog-about.ts
+++ b/src/Scripts/view/options-dialog-about.ts
@@ -44,7 +44,7 @@ export class OptionsDialogAbout {
                                 <option value="${(<any>UpdateChannelType)[key]}" ${(<any>UpdateChannelType)[key] == optionsController.options.updateChannel ? "selected" : ""}>${i18n((<any>strings)[`updateChannel${key}`])}</option>
                             `).join("")}
                         </select> &nbsp;
-                        <span class="display-version">${i18n(strings.appVersion, { version: app.currentVersion.info.build})}</span>
+                        <span class="display-version">${i18n(strings.appVersion, { version: app.currentVersion.info.version})}</span>
                         <span class="ctrl copy-version icon-copy" title="${i18n(strings.copy)}"></span>
                     </div>
                     ${this.canCheckForUpdates ? `<div class="update-status list"></div>` : ""}

--- a/src/Services/ExportDataService.cs
+++ b/src/Services/ExportDataService.cs
@@ -524,7 +524,7 @@
 
                 writer.BeginWorksheet("Bravo Export Summary");
                 writer.BeginRow().Write($"Exported with { AppEnvironment.ApplicationMainWindowTitle }", style: infoStyle);
-                writer.BeginRow().Write($"Version { AppEnvironment.ApplicationProductVersion } (build { AppEnvironment.ApplicationFileVersion })", style: infoStyle);
+                writer.BeginRow().Write($"Version { AppEnvironment.VersionInfo.Version } (build { AppEnvironment.VersionInfo.Build })", style: infoStyle);
                 writer.SkipRows(1);
                 writer.SetDefaultStyle(headerStyle).BeginRow().Write("Worksheet").Write("Table").Write("Rows").Write("Status");
                 writer.SetDefaultStyle(XlsxStyle.Default);

--- a/src/Services/FormatDaxService.cs
+++ b/src/Services/FormatDaxService.cs
@@ -113,7 +113,7 @@
                 ListSeparator = options.ListSeparator ?? ',', // TODO: Dax.Formatter declare ListSeparator nullable
                 DecimalSeparator = options.DecimalSeparator ?? '.', // TODO: Dax.Formatter declare DecimalSeparator nullable
                 CallerApp = AppEnvironment.ApplicationName,
-                CallerVersion = AppEnvironment.ApplicationProductVersion,
+                CallerVersion = AppEnvironment.VersionInfo.Version,
             };
 
             foreach (var measure in measures)

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -109,6 +109,12 @@
         "resolved": "1.0.2739.15",
         "contentHash": "hZg7vHWBg4RIiK3rhkNqX3hcBqqoVXVrrO2BVrVOiSmEgfLa7lY64G1tWh2VY84MfHIFLCAQNwn3Rwvu+ICHyw=="
       },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.10.85, )",
+        "resolved": "3.10.85",
+        "contentHash": "smhqiTAbnI/6NRn+k7m+a65qKY7nREbnFqFgqxiw3JS8kXiBUOxdCxIZFP9TOpCsoh46DbMlBlcd+dWQYAVVCA=="
+      },
       "Swashbuckle.AspNetCore": {
         "type": "Direct",
         "requested": "[7.0.0, )",

--- a/test/Bravo.Tests/Infrastructure/Extensions/StringExtensionsTests.cs
+++ b/test/Bravo.Tests/Infrastructure/Extensions/StringExtensionsTests.cs
@@ -68,26 +68,6 @@
             Assert.StartsWith("Bravo for Power BI", actual);
         }
 
-        [Theory]
-        [InlineData(null, "", 4)]
-        [InlineData("", "", 4)]
-        [InlineData("0.0.0.999-DEV", "0.0.0.999-DEV", 4)]
-        [InlineData("0.9.4", "0.9.4", 4)]
-        [InlineData("0.9.4-internal", "0.9.4-internal", 4)]
-        [InlineData("0.9.4-internal-20220531.2-main-cf160fee710b983bbfb739e5eb1edd542a72b8b5 (0.9.8186.35439)", "0.9.4-internal-20220531.2-main", 4)]
-        [InlineData("0.9.4-internal-20220531.2-main-cf160fee710b983bbfb739e5eb1edd542a72b8b5 (0.9.8186.35439)", "0.9.4-internal-20220531.2", 3)]
-        [InlineData("0.9.4-internal-20220531.2-main-cf160fee710b983bbfb739e5eb1edd542a72b8b5 (0.9.8186.35439)", "0.9.4-internal", 2)]
-        [InlineData("0.9.4-internal-20220531.2-main-cf160fee710b983bbfb739e5eb1edd542a72b8b5 (0.9.8186.35439)", "0.9.4", 1)]
-        [InlineData("0.9.4-internal-20220531.2-main-cf160fee710b983bbfb739e5eb1edd542a72b8b5 (0.9.8186.35439)", "", 0)]
-        [InlineData("0.9.4-internal-20220531.2-main-cf160fee710b983bbfb739e5eb1edd542a72b8b5 (0.9.8186.35439)", "", -1)]
-        public void GetVersionParts_Test(string? value, string expected, int parts)
-        {
-            var actual = value.GetVersionParts(parts);
-
-            Assert.NotNull(actual);
-            Assert.Equal(expected, actual);
-        }
-
         [Fact]
         public void IsPBIDesktopMainWindowTitle_Test()
         {

--- a/version.json
+++ b/version.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.1.0",
+  "assemblyVersion": {
+    "precision": "build"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Replace the two divergent version numbers (3-part product version vs. date-based 4-part file version) with one controlled SemVer declared in version.json and computed by NBGV. AppVersionInfo.Version (clean Major.Minor.Patch) is the single version used everywhere user-facing and for update-check comparisons; AppVersionInfo.Build (Major.Minor.Patch.{gitHeight}) is kept only for diagnostics (telemetry) and is never compared or shown to users.