### PR TITLE
Fix GetReports API to respond 204 on cancellation instead of throwing

### DIFF
--- a/src/Controllers/AnalyzeModelController.cs
+++ b/src/Controllers/AnalyzeModelController.cs
@@ -114,30 +114,24 @@
         /// Returns a list of all open <see cref="PBIDesktopReport"/>
         /// </summary>
         /// <response code="200">Status200OK - Success</response>
+        /// <response code="204">Status204NoContent - User canceled the operation</response>
         [HttpGet]
         [ActionName("ListReports")]
         [Produces(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PBIDesktopReport>))]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesDefaultResponseType]
         public IActionResult GetReports(CancellationToken cancellationToken)
         {
-            var reports = _analyzeModelService.GetReports(cancellationToken);
-            return Ok(reports);
-        }
-
-        /// <summary>
-        /// Returns a list of all open <see cref="PBIDesktopReport"/> reports as fast as possible, providing only process information and without attempting to establish a database connection
-        /// </summary>
-        /// <response code="200">Status200OK - Success</response>
-        [HttpGet]
-        [ActionName("QueryReports")]
-        [Produces(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PBIDesktopReport>))]
-        [ProducesDefaultResponseType]
-        public IActionResult QueryReports(CancellationToken cancellationToken)
-        {
-            var reports = _analyzeModelService.QueryReports(cancellationToken);
-            return Ok(reports);
+            try
+            {
+                var reports = _analyzeModelService.GetReports(cancellationToken);
+                return Ok(reports);
+            }
+            catch (OperationCanceledException)
+            {
+                return NoContent();
+            }
         }
 
         /// <summary>

--- a/src/Controllers/TemplateDevelopmentController.cs
+++ b/src/Controllers/TemplateDevelopmentController.cs
@@ -184,15 +184,24 @@
         /// Returns a list of all open <see cref="PBIDesktopReport"/>
         /// </summary>
         /// <response code="200">Status200OK - Success</response>
+        /// <response code="204">Status204NoContent - User canceled the operation</response>
         [HttpGet]
         [ActionName("GetReports")]
         [Produces(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PBIDesktopReport>))]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesDefaultResponseType]
         public IActionResult GetReports(CancellationToken cancellationToken)
         {
-            var reports = _analyzeModelService.GetReports(cancellationToken);
-            return Ok(reports);
+            try
+            {
+                var reports = _analyzeModelService.GetReports(cancellationToken);
+                return Ok(reports);
+            }
+            catch (OperationCanceledException)
+            {
+                return NoContent();
+            }
         }
 
         /// <summary>

--- a/src/Infrastructure/Services/PowerBI/PBIDesktopService.cs
+++ b/src/Infrastructure/Services/PowerBI/PBIDesktopService.cs
@@ -12,36 +12,11 @@
 
     public interface IPBIDesktopService
     {
-        IEnumerable<PBIDesktopReport> QueryReports(CancellationToken cancellationToken);
-
         IEnumerable<PBIDesktopReport> GetReports(CancellationToken cancellationToken);
     }
 
     internal class PBIDesktopService : IPBIDesktopService
     {
-        public IEnumerable<PBIDesktopReport> QueryReports(CancellationToken cancellationToken)
-        {
-            var processes = ProcessHelper.GetProcessesByName(AppEnvironment.PBIDesktopProcessName);
-            try
-            {
-                var reports = new ConcurrentBag<PBIDesktopReport>();
-
-                foreach (var process in processes)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    var report = PBIDesktopReport.CreateFrom(process, connectionModeEnabled: false);
-                    reports.Add(report);
-                }
-
-                return reports;
-            }
-            finally
-            {
-                processes.ForEach((p) => p.Dispose());
-            }
-        }
-
         public IEnumerable<PBIDesktopReport> GetReports(CancellationToken cancellationToken)
         {
             var processes = ProcessHelper.GetProcessesByName(AppEnvironment.PBIDesktopProcessName);

--- a/src/Scripts/controllers/host.ts
+++ b/src/Scripts/controllers/host.ts
@@ -507,7 +507,8 @@ export class Host extends Dispatchable {
     }
 
     listReports() {
-        return <Promise<PBIDesktopReport[]>>this.apiCall("api/ListReports");
+        return (<Promise<PBIDesktopReport[]>>this.apiCall("api/ListReports"))
+            .then(response => response ?? []);
     }
 
     listDatasets() {

--- a/src/Services/AnalyzeModelService.cs
+++ b/src/Services/AnalyzeModelService.cs
@@ -22,8 +22,6 @@
 
         IEnumerable<PBIDesktopReport> GetReports(CancellationToken cancellationToken);
 
-        IEnumerable<PBIDesktopReport> QueryReports(CancellationToken cancellationToken);
-
         void ExportVpax(PBIDesktopReport report, ExportVpaxMode mode, string path, CancellationToken cancellationToken);
 
         void ExportVpax(PBICloudDataset dataset, string accessToken, ExportVpaxMode mode, string path, CancellationToken cancellationToken);
@@ -94,12 +92,6 @@
         public IEnumerable<PBIDesktopReport> GetReports(CancellationToken cancellationToken)
         {
             var reports = _pbidesktopService.GetReports(cancellationToken);
-            return reports;
-        }
-
-        public IEnumerable<PBIDesktopReport> QueryReports(CancellationToken cancellationToken)
-        {
-            var reports = _pbidesktopService.QueryReports(cancellationToken);
             return reports;
         }
 


### PR DESCRIPTION
This fixes an error where GetReports (via PBIDesktopService.GetReports's Parallel.ForEach with a linked CancellationToken) threw OperationCanceledException on cancellation, which propagated unhandled to the ProblemDetails middleware - this is the source of the AggregateException/ObjectDisposedException observed in telemetry (a logging provider disposed mid-shutdown while handling the exception).