### PR TITLE
Upgrade target framework to .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         global-json-file: global.json
-    - name: setup dotnet 6.0 runtime
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '6.0.x'
     - name: dotnet restore
       run:  dotnet restore
     - name: dotnet build

--- a/src/Bravo.csproj
+++ b/src/Bravo.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
     <UseWindowsForms>True</UseWindowsForms>
     <ApplicationIcon>Assets\bravo.ico</ApplicationIcon>
     <Company>SQLBI</Company>
@@ -17,7 +18,6 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <AnalysisLevel>latest</AnalysisLevel>
-    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
     <IsPackable>false</IsPackable>
     <IsPublishable>true</IsPublishable>
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>

--- a/src/Infrastructure/Authentication/AppAuthenticationHandler.cs
+++ b/src/Infrastructure/Authentication/AppAuthenticationHandler.cs
@@ -13,8 +13,8 @@
 
     internal class AppAuthenticationHandler : AuthenticationHandler<AppAuthenticationSchemeOptions>
     {
-        public AppAuthenticationHandler(IOptionsMonitor<AppAuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) 
-            : base(options, logger, encoder, clock)
+        public AppAuthenticationHandler(IOptionsMonitor<AppAuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+            : base(options, logger, encoder)
         {
         }
 

--- a/src/Infrastructure/Configuration/StartupConfiguration.cs
+++ b/src/Infrastructure/Configuration/StartupConfiguration.cs
@@ -3,7 +3,6 @@
     using Sqlbi.Bravo.Infrastructure.Helpers;
     using Sqlbi.Bravo.Infrastructure.Services;
     using System.IO;
-    using System.Net;
     using System.Net.Http;
     using System.Runtime;
 
@@ -22,7 +21,6 @@
             ConfigureProxy();
             ConfigureDirectories();
             ConfigureMulticoreJit();
-            ConfigureSecurityProtocols();
 
             WebView2Helper.EnsureRuntimeIsInstalled();
         }
@@ -37,17 +35,6 @@
             Directory.SetCurrentDirectory(AppContext.BaseDirectory);
             Directory.CreateDirectory(AppEnvironment.ApplicationDataPath);
             Directory.CreateDirectory(AppEnvironment.ApplicationTempPath);
-        }
-
-        private static void ConfigureSecurityProtocols()
-        {
-            var includeTls = SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
-
-#pragma warning disable CS0618 // Type or member is obsolete - Justification is that we are removing SecurityProtocolType.Ssl3
-            var excludeSsl = ServicePointManager.SecurityProtocol & ~SecurityProtocolType.Ssl3;
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            ServicePointManager.SecurityProtocol = excludeSsl | includeTls;
         }
 
         //private static void ConfigureProcessDpiAwareness()

--- a/src/Infrastructure/Extensions/HostingExtensions.cs
+++ b/src/Infrastructure/Extensions/HostingExtensions.cs
@@ -92,13 +92,13 @@
             // Currently it seems to be not possible to add authentication without adding data protection services
             // This can be worked around by replicating the code from AddAuthentication() without the call to AddDataProtection()
             // See https://github.com/dotnet/aspnetcore/issues/43624
-            
+
             // var builder = services.AddAuthentication(defaultScheme: AppEnvironment.ApiAuthenticationSchema);
 
             services.AddAuthenticationCore();
             //services.AddDataProtection();
             services.AddWebEncoders();
-            services.TryAddSingleton<ISystemClock, SystemClock>();
+            services.TryAddSingleton(TimeProvider.System);
 
             var builder = new AuthenticationBuilder(services);
             services.Configure<AuthenticationOptions>((options) => options.DefaultScheme = AppEnvironment.ApiAuthenticationSchema);

--- a/src/Infrastructure/Helpers/ProcessHelper.cs
+++ b/src/Infrastructure/Helpers/ProcessHelper.cs
@@ -76,7 +76,9 @@
             //{
             //}
 
-            if (control.InvokeRequired)
+            // Control.FromHandle returns null when the handle does not belong to a control of this
+            // process: there is no UI thread to marshal to, so the action runs on the calling thread.
+            if (control is not null && control.InvokeRequired)
             {
                 control.Invoke(action);
             }

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0-windows7.0": {
+    "net10.0-windows7.0": {
       "CsvHelper": {
         "type": "Direct",
         "requested": "[33.0.1, )",
@@ -53,8 +53,7 @@
           "Dax.Metadata": "1.12.0",
           "Dax.ViewVpaExport": "1.12.0",
           "Microsoft.AnalysisServices": "19.104.1",
-          "Newtonsoft.Json": "13.0.3",
-          "System.IO.Packaging": "8.0.1"
+          "Newtonsoft.Json": "13.0.3"
         }
       },
       "Dax.Vpax.Obfuscator": {
@@ -72,10 +71,7 @@
         "type": "Direct",
         "requested": "[6.5.1, )",
         "resolved": "6.5.1",
-        "contentHash": "LgceF4mPguB/q3NWs6T3bitOFnYIANSRvfhASMgVb8ks7fSqY8jbdBHoVEuUDmxg3T7+kF21qSE0jQv9hdpLng==",
-        "dependencies": {
-          "System.Reflection.Metadata": "5.0.0"
-        }
+        "contentHash": "LgceF4mPguB/q3NWs6T3bitOFnYIANSRvfhASMgVb8ks7fSqY8jbdBHoVEuUDmxg3T7+kF21qSE0jQv9hdpLng=="
       },
       "LargeXlsx": {
         "type": "Direct",
@@ -87,10 +83,7 @@
         "type": "Direct",
         "requested": "[2.23.0, )",
         "resolved": "2.23.0",
-        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
-        }
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
       },
       "Microsoft.Identity.Client.Desktop": {
         "type": "Direct",
@@ -137,10 +130,7 @@
         "type": "Direct",
         "requested": "[7.0.0, )",
         "resolved": "7.0.0",
-        "contentHash": "A4jed4QUviDOm7fJNKAJObEAEkEUXmkGL/w0iyCYTzrl1rezTj8LGFHfsVst4Vb9JwFcTpboiDrvdST48avBpw==",
-        "dependencies": {
-          "System.CodeDom": "7.0.0"
-        }
+        "contentHash": "A4jed4QUviDOm7fJNKAJObEAEkEUXmkGL/w0iyCYTzrl1rezTj8LGFHfsVst4Vb9JwFcTpboiDrvdST48avBpw=="
       },
       "Antlr4.Runtime.Standard": {
         "type": "Transitive",
@@ -200,8 +190,7 @@
         "resolved": "4.73.1",
         "contentHash": "NnDLS8QwYqO5ZZecL2oioi1LUqjh5Ewk4bMLzbgiXJbQmZhDLtKwLxL3DpGMlQAJ2G4KgEnvGPKa+OOgffeJbw==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "6.35.0",
-          "System.Diagnostics.DiagnosticSource": "6.0.1"
+          "Microsoft.IdentityModel.Abstractions": "6.35.0"
         }
       },
       "Microsoft.Identity.Client.Broker": {
@@ -253,37 +242,9 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "rJJony+jsxvpfJM9ZGVxjp0DVpalZv8cAhiMSLW6L2hgUWb7k5qPVuzQHWXtkT8lrG1hQ8vWeR+HUwgCQm9J3A=="
-      },
-      "System.CodeDom": {
-        "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "GLltyqEsE5/3IE+zYRP5sNa1l44qKl9v+bfdMcwg+M9qnQf47wK3H0SUR/T+3N4JEQXF3vV4CSuuo0rsg+nq2A=="
-      },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "6.0.1",
-        "contentHash": "KiLYDu2k2J82Q9BJpWiuQqCkFjRBWVq4jDzKKWawVi9KWzyD0XG3cmfX0vqTQlL14Wi9EufJrbL0+KCLTbqWiQ==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
-      "System.IO.Packaging": {
-        "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "KYkIOAvPexQOLDxPO2g0BVoWInnQhPpkFzRqvNrNrMhVT6kqhVr0zEb6KCHlptLFukxnZrjuMVAnxK7pOGUYrw=="
-      },
-      "System.Reflection.Metadata": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       }
     },
-    "net6.0-windows7.0/win-x64": {
+    "net10.0-windows7.0/win-x64": {
       "Microsoft.Web.WebView2": {
         "type": "Direct",
         "requested": "[1.0.2739.15, )",
@@ -294,10 +255,7 @@
         "type": "Direct",
         "requested": "[7.0.0, )",
         "resolved": "7.0.0",
-        "contentHash": "A4jed4QUviDOm7fJNKAJObEAEkEUXmkGL/w0iyCYTzrl1rezTj8LGFHfsVst4Vb9JwFcTpboiDrvdST48avBpw==",
-        "dependencies": {
-          "System.CodeDom": "7.0.0"
-        }
+        "contentHash": "A4jed4QUviDOm7fJNKAJObEAEkEUXmkGL/w0iyCYTzrl1rezTj8LGFHfsVst4Vb9JwFcTpboiDrvdST48avBpw=="
       },
       "Microsoft.AnalysisServices.AdomdClient": {
         "type": "Transitive",

--- a/test/Bravo.Tests/Bravo.Tests.csproj
+++ b/test/Bravo.Tests/Bravo.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>


### PR DESCRIPTION
Move from net6-windows, which is out of support, to net10.0-windows, matching the SDK already pinned in global.json. Also, changes include removing ConfigureSecurityProtocols. On .NET 10, ServicePointManager settings no longer affect HttpClient or SslStream, so the method is no longer required. TLS protocol selection is delegated to the operating system, following the recommended approach.