### PR TITLE
Fix invalid catalog after `pbiazure://` to XMLA redirect

### DIFF
--- a/src/Infrastructure/Services/ConnectionWrapper.cs
+++ b/src/Infrastructure/Services/ConnectionWrapper.cs
@@ -53,7 +53,6 @@ internal class TabularConnectionWrapper : IDisposable
         if (open)
         {
             connection.Open();
-            connection.ChangeDatabase(Database.Name);
         }
 
         return connection;
@@ -88,11 +87,10 @@ internal class TabularConnectionWrapper : IDisposable
 
 internal class AdomdConnectionWrapper : IDisposable
 {
-    private AdomdConnectionWrapper(string connectionString, string databaseName)
+    private AdomdConnectionWrapper(string connectionString)
     {
         Connection = new AdomdConnection(connectionString);
         ProcessHelper.RunOnUISynchronizationContext(() => Connection.Open());
-        Connection.ChangeDatabase(databaseName);
 
         IsServerVersion13OrGreater = Version.TryParse(Connection.ServerVersion, out var version) && version >= new Version(13, 0);
     }
@@ -134,20 +132,16 @@ internal class AdomdConnectionWrapper : IDisposable
 
     public static AdomdConnectionWrapper ConnectTo(PBICloudDataset dataset, string accessToken)
     {
-        BravoUnexpectedException.ThrowIfNull(dataset.ExternalDatabaseName);
-
         var connectionString = ConnectionStringHelper.BuildFor(dataset, accessToken);
-        var connection = new AdomdConnectionWrapper(connectionString, dataset.ExternalDatabaseName);
+        var connection = new AdomdConnectionWrapper(connectionString);
 
         return connection;
     }
 
     public static AdomdConnectionWrapper ConnectTo(PBIDesktopReport report)
     {
-        BravoUnexpectedException.ThrowIfNull(report.DatabaseName);
-
         var connectionString = ConnectionStringHelper.BuildFor(report);
-        var connection = new AdomdConnectionWrapper(connectionString, report.DatabaseName);
+        var connection = new AdomdConnectionWrapper(connectionString);
 
         return connection;
     }


### PR DESCRIPTION
AdomdConnectionWrapper previously called ChangeDatabase() using the internal catalog name format (sobe_wowvirtualserver-<DBName>). Since AdomdClient 19.96.1, the Analyze-in-Excel to public XMLA redirect is no longer restricted to an application ID allow-list. As a result, opening a cloud dataset connection now transparently redirects from pbiazure:// to powerbi:// and updates the catalog to the dataset's display name. The subsequent explicit call to ChangeDatabase() sent the outdated catalog name to the XMLA endpoint, causing it to reject the connection as a non-existent database. ChangeDatabase() was redundant in both wrappers, as the catalog is already specified by the Initial Catalog connection string property. This call has been removed, and the effective catalog is now read directly from Connection.Database when needed.