### PR TITLE
Save crash reports and simplify startup dialogs

### DIFF
--- a/src/Controllers/ExportDataController.cs
+++ b/src/Controllers/ExportDataController.cs
@@ -1,13 +1,9 @@
-﻿using System.IO;
-using System.Net.Mime;
+﻿using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Sqlbi.Bravo.Infrastructure.Extensions;
 using Sqlbi.Bravo.Infrastructure.Helpers;
-using Sqlbi.Bravo.Infrastructure.Windows;
 using Sqlbi.Bravo.Models;
 using Sqlbi.Bravo.Models.ExportData;
 using Sqlbi.Bravo.Services;
@@ -47,12 +43,6 @@ public class ExportDataController : ControllerBase
     {
         if (WindowDialogHelper.BrowseFolderDialog(out var path, cancellationToken))
         {
-            if (request.Settings!.CreateSubfolder)
-            {
-                if (!GetExportSubfolderPath(ref path, name: request.Report!.ReportName))
-                    return NoContent();
-            }
-
             var job = _exportDataService.ExportDelimitedTextFile(request.Report!, request.Settings!, path, cancellationToken);
             return Ok(job);
         }
@@ -81,12 +71,6 @@ public class ExportDataController : ControllerBase
 
         if (WindowDialogHelper.BrowseFolderDialog(out var path, cancellationToken))
         {
-            if (request.Settings!.CreateSubfolder)
-            {
-                if (!GetExportSubfolderPath(ref path, name: request.Dataset!.DisplayName))
-                    return NoContent();
-            }
-
             var job = _exportDataService.ExportDelimitedTextFile(request.Dataset!, request.Settings!, path, session.AuthenticationResult.AccessToken, cancellationToken);
             return Ok(job);
         }
@@ -184,53 +168,5 @@ public class ExportDataController : ControllerBase
             return NoContent();
 
         return Ok(job);
-    }
-
-    private static bool GetExportSubfolderPath(ref string path, string? name)
-    {
-        if (name.IsNullOrWhiteSpace())
-        {
-            name = "New Folder";
-        }
-
-        var subfolderName = name.ReplaceInvalidPathChars();
-        var subfolderPath = Path.Combine(path, subfolderName);
-
-        if (Directory.Exists(subfolderPath))
-        {
-            var overwriteButton = new TaskDialogCommandLinkButton("&Overwrite", "Overwrite and replace files in the destination folder");
-            var keepbothButton = new TaskDialogCommandLinkButton("&Keep Both", "Files will be exported to a new folder");
-            var cancelButton = new TaskDialogCommandLinkButton("&Cancel", "Cancel export");
-            var heading = $"The destination folder you chose already contains a subfolder named '{subfolderName}'";
-            var text = "Choose an option to proceed";
-
-            var clickedButton = MessageDialog.ShowDialog(heading, text, footnoteText: null, allowCancel: true, overwriteButton, keepbothButton, cancelButton);
-
-            if (clickedButton == overwriteButton)
-            {
-                //
-            }
-            else if (clickedButton == keepbothButton)
-            {
-                for (var i = 1; /**/ ; i++)
-                {
-                    var uniquePath = Path.Combine(path, $"{subfolderName} - {i}");
-
-                    if (!Directory.Exists(uniquePath))
-                    {
-                        subfolderPath = uniquePath;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                path = string.Empty;
-                return false;
-            }
-        }
-
-        path = subfolderPath;
-        return true;
     }
 }

--- a/src/Host/BravoApplicationInitializer.cs
+++ b/src/Host/BravoApplicationInitializer.cs
@@ -9,15 +9,13 @@ using Sqlbi.Bravo.Infrastructure.Services;
 namespace Sqlbi.Bravo.Host;
 
 /// <summary>
-/// Provides the initialization phase that precedes the application.
+/// Initializes the application process, applying process-wide settings
+/// and composing the necessary components before the host is created.
 /// </summary>
 internal static class BravoApplicationInitializer
 {
     /// <summary>
-    /// Initializes the process: applies the process-wide settings and composes what the process owns
-    /// before a host exists — as explicit objects in dependency order, no container — returning them
-    /// in the context. <see cref="BravoApplicationBuilder"/> later publishes them to the one real
-    /// service provider.
+    /// Initializes the application process, applying process-wide settings
     /// </summary>
     public static BravoApplicationInitializationContext Initialize()
     {

--- a/src/Infrastructure/AppEnvironment.cs
+++ b/src/Infrastructure/AppEnvironment.cs
@@ -3,13 +3,11 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
 using System.Text.Json;
 using Microsoft.Win32;
 using Sqlbi.Bravo.Infrastructure.Configuration;
 using Sqlbi.Bravo.Infrastructure.Configuration.Settings;
+using Sqlbi.Bravo.Infrastructure.Diagnostics;
 using Sqlbi.Bravo.Infrastructure.Extensions;
 using Sqlbi.Bravo.Infrastructure.Helpers;
 using Sqlbi.Bravo.Infrastructure.Security;
@@ -81,7 +79,6 @@ internal static class AppEnvironment
 
         ProcessId = Environment.ProcessId;
         SessionId = currentProcess.SessionId;
-        ProcessPath = Environment.ProcessPath!;
 
         ApplicationDataPath = Path.Combine(Environment.GetFolderPath(DeploymentMode == AppDeploymentMode.Packaged ? Environment.SpecialFolder.UserProfile : Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.DoNotVerify), ApplicationName);
         ApplicationTempPath = Path.Combine(ApplicationDataPath, ".temp");
@@ -91,8 +88,6 @@ internal static class AppEnvironment
 
         Diagnostics = new ConcurrentDictionary<DiagnosticMessage, DiagnosticMessage>();
         DefaultJsonOptions = new(JsonSerializerDefaults.Web) { MaxDepth = 32 }; // see Microsoft.AspNetCore.Mvc.JsonOptions.JsonSerializerOptions
-
-        AddEnvironmentDiagnosticInfo();
     }
 
     /// <summary>
@@ -102,8 +97,6 @@ internal static class AppEnvironment
     public static int SessionId { get; }
 
     public static int ProcessId { get; }
-
-    public static string ProcessPath { get; }
 
     public static AppPublishMode PublishMode
     {
@@ -166,37 +159,6 @@ internal static class AppEnvironment
         var message = DiagnosticMessage.Create(type, severity, name, content);
 
         _ = Diagnostics.TryAdd(message, message);
-    }
-
-    private static void AddEnvironmentDiagnosticInfo()
-    {
-        if (!IsDiagnosticLevelVerbose)
-            return;
-
-        var targetFramework = typeof(Program).Assembly.GetCustomAttributes(typeof(TargetFrameworkAttribute), inherit: false).OfType<TargetFrameworkAttribute>().FirstOrDefault();
-
-        var info = new
-        {
-            SystemOSVersion = Environment.OSVersion.VersionString,
-            SystemProcessorCount = Environment.ProcessorCount,
-            ProcessId,
-            ProcessPath,
-            ProcessSessionId = SessionId,
-            RuntimeOSDescription = RuntimeInformation.OSDescription.ToString(),
-            RuntimeOSVersion = RuntimeInformation.RuntimeIdentifier,
-            RuntimeFrameworkDescription = RuntimeInformation.FrameworkDescription,
-            TargetFrameworkName = targetFramework?.FrameworkName ?? "n/a",
-            WebView2VersionInfo,
-            //
-            ApplicationPublishMode = PublishMode.ToString(),
-            ApplicationDeploymentMode = DeploymentMode.ToString(),
-            ApplicationVersion = AppVersion.InformationalVersion,
-            ApplicationDataPath,
-            ApplicationTempPath,
-            ApplicationUserSettingsFilePath = UserSettingsFilePath,
-        };
-
-        AddDiagnostics(DiagnosticMessageType.Json, name: $"{nameof(AppEnvironment)}.EnvironmentInfo", content: JsonSerializer.Serialize(info));
     }
 
     private static AppDeploymentMode GetDeploymentMode()

--- a/src/Infrastructure/AppWindow.cs
+++ b/src/Infrastructure/AppWindow.cs
@@ -14,6 +14,7 @@ using Microsoft.Web.WebView2.WinForms;
 using Sqlbi.Bravo.Host;
 using Sqlbi.Bravo.Infrastructure.Configuration;
 using Sqlbi.Bravo.Infrastructure.Configuration.Settings;
+using Sqlbi.Bravo.Infrastructure.Diagnostics;
 using Sqlbi.Bravo.Infrastructure.Extensions;
 using Sqlbi.Bravo.Infrastructure.Helpers;
 using Sqlbi.Bravo.Infrastructure.Messages;
@@ -183,6 +184,12 @@ window.external = {
         CenterToScreen();
 
         _instanceActivationEvents.ActivationRequested += OnActivationRequestedRestoreWindowToForeground;
+
+        if (AppEnvironment.IsDiagnosticLevelVerbose)
+        {
+            var content = EnvironmentInfo.Collect().ToDictionary();
+            AppEnvironment.AddDiagnostics(DiagnosticMessageType.Json, name: $"{nameof(AppWindow)}.{nameof(EnvironmentInfo)}", content: JsonSerializer.Serialize(content));
+        }
     }
 
     private void OnFormClosed(object? sender, FormClosedEventArgs e)

--- a/src/Infrastructure/Diagnostics/EnvironmentInfo.cs
+++ b/src/Infrastructure/Diagnostics/EnvironmentInfo.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Sqlbi.Bravo.Infrastructure.Telemetry;
+
+namespace Sqlbi.Bravo.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Provides diagnostic information about the environment in which the application is running.
+/// </summary>
+internal sealed class EnvironmentInfo
+{
+    private readonly IReadOnlyList<KeyValuePair<string, string>> _entries;
+
+    /// <summary>
+    /// Collects the environment information and returns an instance of <see cref="EnvironmentInfo"/>.
+    /// </summary>
+    public static EnvironmentInfo Collect()
+    {
+        var entries = new KeyValuePair<string, string>[]
+        {
+            new("TimestampUtc", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)),
+            new("TimestampLocal", DateTime.Now.ToString("O", CultureInfo.InvariantCulture)),
+            // Application
+            new("ApplicationSessionId", SafeRead(() => TelemetrySessionInfo.SessionId)),
+            new("ApplicationVersion", SafeRead(() => AppVersion.InformationalVersion)),
+            new("ApplicationPublishMode", SafeRead(() => AppEnvironment.PublishMode.ToString())),
+            new("ApplicationDeploymentMode", SafeRead(() => AppEnvironment.DeploymentMode.ToString())),
+            new("ApplicationDataPath", SafeRead(() => AppEnvironment.ApplicationDataPath)),
+            // Process
+            new("ProcessId", SafeRead(() => Environment.ProcessId.ToString(CultureInfo.InvariantCulture))),
+            new("ProcessPath", SafeRead(() => Environment.ProcessPath)),
+            new("ProcessSessionId", SafeRead(() => AppEnvironment.SessionId.ToString(CultureInfo.InvariantCulture))),
+            new("ProcessArchitecture", SafeRead(() => RuntimeInformation.ProcessArchitecture.ToString())),
+            new("ProcessProcessorCount", SafeRead(() => Environment.ProcessorCount.ToString(CultureInfo.InvariantCulture))),
+            // Machine
+            new("OSDescription", SafeRead(() => RuntimeInformation.OSDescription)),
+            new("OSArchitecture", SafeRead(() => RuntimeInformation.OSArchitecture.ToString())),
+            // Runtime
+            new("RuntimeDescription", SafeRead(() => RuntimeInformation.FrameworkDescription)),
+            new("RuntimeIdentifier", SafeRead(() => RuntimeInformation.RuntimeIdentifier)),
+            // Components
+            new("WebView2Version", SafeRead(() => AppEnvironment.WebView2VersionInfo)),
+        };
+
+        return new EnvironmentInfo(entries);
+    }
+
+    private EnvironmentInfo(IReadOnlyList<KeyValuePair<string, string>> entries)
+    {
+        _entries = entries;
+    }
+
+    /// <summary>
+    /// Returns the environment information as a text block.
+    /// </summary>
+    public string ToText()
+    {
+        var builder = new StringBuilder();
+
+        builder.AppendLine("# Environment Information");
+        builder.AppendLine();
+
+        foreach (var (name, value) in _entries)
+            builder.Append($"- {name}: ").AppendLine(value);
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Returns the environment information as dictionary.
+    /// </summary>
+    public Dictionary<string, string> ToDictionary()
+    {
+        return _entries.ToDictionary((entry) => entry.Key, (entry) => entry.Value);
+    }
+
+    internal static string SafeRead(Func<string?> read, string fallback = "n/a")
+    {
+        try
+        {
+            return read() ?? fallback;
+        }
+        catch (Exception ex)
+        {
+            return $"unavailable ({ex.GetType().Name})";
+        }
+    }
+}

--- a/src/Infrastructure/Diagnostics/ErrorReport.cs
+++ b/src/Infrastructure/Diagnostics/ErrorReport.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Sqlbi.Bravo.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Represents a report of an error that occurred in the application.
+/// </summary>
+internal sealed class ErrorReport
+{
+    private const string FileName = "ErrorReport.txt";
+
+    private readonly EnvironmentInfo _environment;
+    private readonly Lazy<string> _text;
+
+    /// <summary>
+    /// Creates an <see cref="ErrorReport"/> instance for the given exception.
+    /// </summary>
+    public static ErrorReport Create(Exception exception)
+    {
+        var environment = EnvironmentInfo.Collect();
+        return new ErrorReport(exception, environment);
+    }
+
+    internal ErrorReport(Exception exception, EnvironmentInfo environment)
+    {
+        Exception = exception;
+        _environment = environment;
+        _text = new Lazy<string>(GenerateText);
+    }
+
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// The text representation of the error report.
+    /// </summary>
+    public string Text => _text.Value;
+
+    /// <summary>
+    /// The file path where the error report was saved, or null if saving failed.
+    /// </summary>
+    public string? FilePath { get; private set; }
+
+    /// <summary>
+    /// Attempts to save the error report to a file in the application data folder.
+    /// </summary>
+    public bool TrySave()
+    {
+        try
+        {
+            var filePath = Path.Combine(AppEnvironment.ApplicationDataPath, FileName);
+            File.WriteAllText(filePath, Text, Encoding.UTF8);
+
+            FilePath = filePath;
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to copy the report to the clipboard.
+    /// </summary>
+    public bool TryCopyToClipboard()
+    {
+        try
+        {
+            Clipboard.SetDataObject(
+                data: new DataObject(DataFormats.UnicodeText, Text),
+                copy: true,
+                retryTimes: 10,
+                retryDelay: 100);
+
+            return true;
+        }
+        catch (ExternalException)
+        {
+            return false;
+        }
+    }
+
+    public override string ToString() => Text;
+
+    private string GenerateText()
+    {
+        var builder = new StringBuilder();
+
+        builder.AppendLine(_environment.ToText());
+
+        builder.AppendLine("# Error Details");
+        builder.AppendLine();
+        builder.AppendLine("```");
+        builder.AppendLine(Exception.ToString());
+        builder.AppendLine("```");
+
+        return builder.ToString();
+    }
+}

--- a/src/Infrastructure/Diagnostics/ErrorReportDialog.cs
+++ b/src/Infrastructure/Diagnostics/ErrorReportDialog.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Text;
+using System.Windows.Forms;
+using Sqlbi.Bravo.Infrastructure.Helpers;
+using Sqlbi.Bravo.Infrastructure.Windows.Dialogs;
+
+namespace Sqlbi.Bravo.Infrastructure.Diagnostics;
+
+/// <summary>
+/// Provides a dialog to report an error that occurred in the application.
+/// </summary>
+internal static class ErrorReportDialog
+{
+    //private const string BugReportUrl = "https://github.com/sql-bi/Bravo/issues/new";
+
+    public static void Show(ErrorReport report)
+    {
+        //var reportButton = new TaskDialogCommandLinkButton("&Report this issue", "Copies the report to the clipboard and opens the Bravo issue tracker in your browser, where you can paste it.");
+        var copyButton = new TaskDialogCommandLinkButton("&Copy to clipboard", "Copies the crash report to the clipboard.")
+        {
+            // Keep the dialog open after clicking the button
+            AllowCloseDialog = false,
+        };
+
+        copyButton.Click += (_, _) => _ = report.TryCopyToClipboard();
+
+        var clickedButton = TaskDialogBuilder.Create()
+            .WithCaption(AppEnvironment.ApplicationMainWindowTitle)
+            .WithIcon(TaskDialogIcon.Error)
+            .WithStartupLocation(TaskDialogStartupLocation.CenterScreen)
+            .WithAllowCancel()
+            .WithSizeToContent()
+            .WithEnableLinks((href) => _ = ProcessHelper.Open(href))
+            .WithHeading("Bravo encountered an unexpected error.")
+            .WithText(GetText(report))
+            .AddButtons(/*reportButton,*/ copyButton, TaskDialogButton.Close)
+            .WithDefaultButton(copyButton)
+            .Show();
+
+        //if (clickedButton == reportButton)
+        //{
+        //    _ = report.TryCopyToClipboard();
+        //    _ = ProcessHelper.OpenBrowser(new Uri(BugReportUrl, UriKind.Absolute));
+        //}
+    }
+
+    private static string GetText(ErrorReport report)
+    {
+        var text = new StringBuilder();
+
+        text.AppendLine(report.FilePath is not null
+            ? "A crash report has been saved and can be used to diagnose the problem."
+            : "The crash report could not be saved.");
+
+        if (report.FilePath is not null)
+        {
+            text.AppendLine();
+            text.AppendLine("Report file:");
+            text.Append("<a href=\"").Append(report.FilePath).Append("\">").Append(report.FilePath).AppendLine("</a>");
+        }
+
+        text.AppendLine();
+        text.AppendLine("Exception:");
+        text.AppendLine($"{report.Exception.GetType().FullName}: {report.Exception.Message}");
+
+        text.AppendLine();
+        text.AppendLine("Location:");
+        text.AppendLine(GetExceptionLocation(report.Exception));
+
+        return text.ToString();
+
+        static string GetExceptionLocation(Exception exception)
+        {
+            if (exception.TargetSite is { } method)
+            {
+                if (method.DeclaringType is { } type)
+                {
+                    return $"{type.FullName}.{method.Name}";
+                }
+            }
+             
+            return exception.Source ?? "<none>";
+        }
+    }
+}

--- a/src/Infrastructure/Helpers/ExceptionHelper.cs
+++ b/src/Infrastructure/Helpers/ExceptionHelper.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
-using System.Windows.Forms;
 
 namespace Sqlbi.Bravo.Infrastructure.Helpers;
 
@@ -61,48 +60,5 @@ internal static class ExceptionHelper
         }
 
         return false;
-    }
-
-    public static void ShowDialog(Exception exception)
-    {
-        var page = new TaskDialogPage()
-        {
-            Caption = AppEnvironment.ApplicationMainWindowTitle,
-            Heading = @$"Unhandled exception has occurred. The application will be shut down and the error details will be logged in the Windows Event Log.
-
-[{exception.GetType().Name}] {exception.Message}",
-            Icon = TaskDialogIcon.Error,
-            AllowCancel = false,
-            Buttons =
-            {
-                new TaskDialogCommandLinkButton("&Copy details", "Copy error details to clipboard and close")
-                {
-                    Tag = 10
-                },
-                new TaskDialogCommandLinkButton("&Close", "Terminate the application")
-                {
-                    Tag = 20
-                },
-            },
-            Expander = new TaskDialogExpander()
-            {
-                Expanded = false,
-                Text = $"{exception}",
-                Position = TaskDialogExpanderPosition.AfterFootnote,
-            }
-        };
-
-        var dialogButton = TaskDialog.ShowDialog(page, TaskDialogStartupLocation.CenterScreen);
-
-        switch (dialogButton.Tag)
-        {
-            case 10:
-                Clipboard.SetText(page.Expander.Text, TextDataFormat.Text);
-                break;
-            case 20:
-                break;
-            default:
-                throw new BravoUnexpectedInvalidOperationException($"Unhandled {nameof(TaskDialogButton)} result ({dialogButton.Tag})");
-        }
     }
 }

--- a/src/Infrastructure/Helpers/ProcessHelper.cs
+++ b/src/Infrastructure/Helpers/ProcessHelper.cs
@@ -179,12 +179,13 @@ internal static class ProcessHelper
     {
         if (File.Exists(path))
         {
+            const string Txt = ".txt";
             const string Pbix = ".pbix";
             const string Xlsx = ".xlsx";
             const string CodeWorkspace = ".code-workspace";
 
             var extension = Path.GetExtension(path);
-            var isAllowed = (new[] { Pbix, Xlsx, CodeWorkspace }).Any((ext) => ext.EqualsI(extension));
+            var isAllowed = (new[] { Txt, Pbix, Xlsx, CodeWorkspace }).Any((ext) => ext.EqualsI(extension));
             var isPbix = extension.EqualsI(Pbix);
 
             if (isAllowed)

--- a/src/Infrastructure/Helpers/WebView2Helper.cs
+++ b/src/Infrastructure/Helpers/WebView2Helper.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Web.WebView2.Core;
 using Sqlbi.Bravo.Infrastructure.Configuration.Settings;
 using Sqlbi.Bravo.Infrastructure.Extensions;
-using Sqlbi.Bravo.Infrastructure.Windows;
+using Sqlbi.Bravo.Infrastructure.Windows.Dialogs;
 using Sqlbi.Bravo.Infrastructure.Windows.Interop;
 
 namespace Sqlbi.Bravo.Infrastructure.Helpers;
@@ -21,11 +19,14 @@ internal static class WebView2Helper
     //internal static extern int GetAvailableCoreWebView2BrowserVersionString([In][MarshalAs(UnmanagedType.LPWStr)] string? browserExecutableFolder, [MarshalAs(UnmanagedType.LPWStr)] ref string versionInfo);
 
     /// <summary>
-    /// The Bootstrapper is a tiny installer that downloads the Evergreen Runtime matching device architecture and installs it locally.
-    /// https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section
+    /// The bootstrapper URL Microsoft provides to download the Evergreen WebView2 Runtime.
     /// </summary>
-    public static string EvergreenRuntimeBootstrapperUrl = "https://go.microsoft.com/fwlink/p/?LinkId=2124703";
-    public static string MicrosoftReferenceUrl = "https://developer.microsoft.com/en-us/microsoft-edge/webview2";
+    private const string BootstrapperDownloadUrl = "https://go.microsoft.com/fwlink/p/?LinkId=2124703";
+
+    /// <summary>
+    /// The page Microsoft addresses to end users who need to install the runtime themselves.
+    /// </summary>
+    private const string ConsumerDownloadPageUrl = "https://developer.microsoft.com/microsoft-edge/webview2/consumer/";
 
     public static void TryAndIgnoreUnsupportedError(Action action)
     {
@@ -74,53 +75,51 @@ internal static class WebView2Helper
         */
     }
 
+    /// <summary>
+    /// Ensures that the WebView2 Runtime is installed. If not, prompts the user to download and install it.
+    /// </summary>
     public static void EnsureRuntimeIsInstalled()
     {
         if (AppEnvironment.IsWebView2RuntimeInstalled)
             return;
 
-        var heading = $"{AppEnvironment.ApplicationMainWindowTitle} requires the Microsoft Edge WebView2 runtime which is not currently installed.\r\n\r\nChoose an option to proceed with the installation:";
-        var footnoteText = $"For more details please refer to the following address:\r\n\r\n - {AppEnvironment.ApplicationWebsiteUrl}\r\n - {MicrosoftReferenceUrl}";
-        var automaticButton = new TaskDialogCommandLinkButton("&Automatic", "Download and install Microsoft Edge WebView2 runtime now");
-        var manualButton = new TaskDialogCommandLinkButton("&Manual", "Open the browser on the download page");
-        var cancelButton = new TaskDialogCommandLinkButton("&Cancel", "Close the application without installing");
+        var downloadButton = new TaskDialogCommandLinkButton("&Download it now", "You will need to run the downloaded installer, then start Bravo again.");
 
-        var dialogButton = MessageDialog.ShowDialog(heading, text: null, footnoteText, allowCancel: false, automaticButton, manualButton, cancelButton);
+        var clickedButton = TaskDialogBuilder.Create()
+            .WithCaption(AppEnvironment.ApplicationMainWindowTitle)
+            .WithCurrentProcessIcon()
+            .WithStartupLocation(TaskDialogStartupLocation.CenterScreen)
+            .WithAllowCancel()
+            .WithSizeToContent()
+            .WithEnableLinks(OpenBrowser)
+            .WithHeading("You must install WebView2 Runtime to run this application.")
+            .WithText("Bravo needs Microsoft Edge WebView2 Runtime to display its user interface.")
+            .WithExpander(GetDetails(), expanded: false, TaskDialogExpanderPosition.AfterText, expandedButtonText: "Hide details", collapsedButtonText: "Show details")
+            .AddButtons(downloadButton, TaskDialogButton.Close)
+            .WithDefaultButton(downloadButton)
+            .Show();
 
-        if (dialogButton == automaticButton)
-        {
-            DownloadAndInstallRuntime();
-        }
-        else if (dialogButton == manualButton)
-        {
-            var address = new Uri(MicrosoftReferenceUrl, uriKind: UriKind.Absolute);
-            _ = ProcessHelper.OpenBrowser(address);
-        }
-        else if (dialogButton == cancelButton)
-        {
-            //
-        }
+        if (clickedButton == downloadButton)
+            OpenBrowser(BootstrapperDownloadUrl);
 
-        Environment.Exit(NativeMethods.ERROR_SUCCESS);
-    }
+        // The application cannot run without WebView2 Runtime, so exit with a specific error code
+        Environment.Exit(NativeMethods.ERROR_CANCELLED);
 
-    private static void DownloadAndInstallRuntime()
-    {
-        // TODO: use http client from pool, add proxy support
-        using var httpClient = new HttpClient();
+        static string GetDetails()
+            => $"""
+               Architecture: {RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()}
+               Windows version: {Environment.OSVersion.Version}
+               Bravo version: {AppVersion.SemanticVersion}
 
-        var fileBytes = httpClient.GetByteArrayAsync(EvergreenRuntimeBootstrapperUrl).GetAwaiter().GetResult();
-        var filePath = Path.Combine(AppEnvironment.ApplicationTempPath, $"MicrosoftEdgeWebview2Setup-{DateTime.Now:yyyyMMddHHmmss}.exe");
+               Learn more:
+               <a href="{ConsumerDownloadPageUrl}">{ConsumerDownloadPageUrl}</a>
 
-        File.WriteAllBytes(filePath, fileBytes);
+               Download link:
+               <a href="{BootstrapperDownloadUrl}">{BootstrapperDownloadUrl}</a>
+               """;
 
-        using var process = Process.Start(filePath); // add switches ? i.e. /silent /install
-        process.WaitForExit();
-
-        if (process.ExitCode != NativeMethods.ERROR_SUCCESS)
-        {
-            ExceptionHelper.WriteToEventLog($"WebView2 bootstrapper exit code '{process.ExitCode}'", EventLogEntryType.Warning);
-        }
+        static void OpenBrowser(string url)
+            => ProcessHelper.OpenBrowser(new Uri(url, UriKind.Absolute));
     }
 
     public static string GetProxyArguments(ProxySettings? proxySettings, IWebProxy systemProxy)

--- a/src/Infrastructure/Windows/Dialogs/TaskDialogBuilder.cs
+++ b/src/Infrastructure/Windows/Dialogs/TaskDialogBuilder.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Sqlbi.Bravo.Infrastructure.Windows.Dialogs;
+
+/// <summary>
+/// Provides a fluent builder for creating and showing a <see cref="TaskDialogPage"/> dialog.
+/// </summary>
+public sealed class TaskDialogBuilder
+{
+    private static readonly Lazy<TaskDialogIcon?> s_currentProcessIcon = new(LoadCurrentProcessIcon);
+
+    private readonly TaskDialogPage _page;
+    private IntPtr _ownerHandle = IntPtr.Zero;
+    private TaskDialogStartupLocation _startupLocation = TaskDialogStartupLocation.CenterOwner;
+
+    /// <summary>
+    /// Creates a new <see cref="TaskDialogBuilder"/> instance.
+    /// </summary>
+    public static TaskDialogBuilder Create() => new();
+
+    private TaskDialogBuilder()
+    {
+        _page = new TaskDialogPage
+        {
+            AllowCancel = false,
+            AllowMinimize = false
+        };
+    }
+
+    public TaskDialogBuilder WithCaption(string caption)
+    {
+        _page.Caption = caption;
+        return this;
+    }
+
+    public TaskDialogBuilder WithHeading(string heading)
+    {
+        _page.Heading = heading;
+        return this;
+    }
+
+    public TaskDialogBuilder WithText(string text)
+    {
+        _page.Text = text;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the dialog icon to the icon of the current process, if available.
+    /// </summary>
+    public TaskDialogBuilder WithCurrentProcessIcon()
+    {
+        if (s_currentProcessIcon.Value is { } icon)
+            _page.Icon = icon;
+
+        return this;
+    }
+
+    public TaskDialogBuilder WithIcon(TaskDialogIcon icon)
+    {
+        _page.Icon = icon;
+        return this;
+    }
+
+    public TaskDialogBuilder WithFootnote(string text, TaskDialogIcon? icon = null)
+    {
+        _page.Footnote = new TaskDialogFootnote(text)
+        {
+            Icon = icon,
+        };
+        return this;
+    }
+
+    public TaskDialogBuilder WithExpander(
+        string text,
+        bool expanded = false,
+        TaskDialogExpanderPosition position = TaskDialogExpanderPosition.AfterText,
+        string? expandedButtonText = null,
+        string? collapsedButtonText = null)
+    {
+        _page.Expander = new TaskDialogExpander(text)
+        {
+            Expanded = expanded,
+            Position = position,
+            ExpandedButtonText = expandedButtonText,
+            CollapsedButtonText = collapsedButtonText,
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Enables clickable links in the dialog text and footnote, and invokes the specified callback when a link is clicked.
+    /// </summary>
+    public TaskDialogBuilder WithEnableLinks(Action<string> linkClicked)
+    {
+        _page.EnableLinks = true;
+        _page.LinkClicked += (_, e) => linkClicked(e.LinkHref);
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the dialog to automatically size to its content. If false, the dialog will have a fixed size.
+    /// </summary>
+    public TaskDialogBuilder WithSizeToContent(bool sizeToContent = true)
+    {
+        _page.SizeToContent = sizeToContent;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the default button that is focused when the dialog is shown.
+    /// </summary>
+    public TaskDialogBuilder WithDefaultButton(TaskDialogButton button)
+    {
+        _page.DefaultButton = button;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the window that owns the dialog to the main window of the current process.
+    /// </summary>
+    public TaskDialogBuilder WithCurrentProcessMainWindowOwner()
+    {
+        using var process = Process.GetCurrentProcess();
+
+        return WithOwner(process.MainWindowHandle);
+    }
+
+    /// <summary>
+    /// Sets the window that owns the dialog. Without an owner the dialog is top-level.
+    /// </summary>
+    public TaskDialogBuilder WithOwner(IntPtr ownerHandle)
+    {
+        _ownerHandle = ownerHandle;
+        return this;
+    }
+
+    public TaskDialogBuilder WithStartupLocation(TaskDialogStartupLocation startupLocation)
+    {
+        _startupLocation = startupLocation;
+        return this;
+    }
+
+    public TaskDialogBuilder WithAllowCancel(bool allowCancel = true)
+    {
+        _page.AllowCancel = allowCancel;
+        return this;
+    }
+
+    public TaskDialogBuilder AddButtons(params TaskDialogButton[] buttons)
+    {
+        foreach (var button in buttons)
+            _page.Buttons.Add(button);
+
+        return this;
+    }
+
+    public TaskDialogPage Build()
+    {
+        return _page;
+    }
+
+    /// <summary>
+    /// Shows the dialog modally and returns the button the user chose.
+    /// </summary>
+    public TaskDialogButton Show()
+    {
+        if (_ownerHandle != IntPtr.Zero)
+        {
+            return TaskDialog.ShowDialog(_ownerHandle, _page, _startupLocation);
+        }
+
+        return TaskDialog.ShowDialog(_page, _startupLocation);
+    }
+
+    private static TaskDialogIcon? LoadCurrentProcessIcon()
+    {
+        if (Environment.ProcessPath is { } path && Icon.ExtractAssociatedIcon(path) is { } icon)
+            return new TaskDialogIcon(icon);
+
+        return null;
+    }
+}

--- a/src/Infrastructure/Windows/WindowDialogs.cs
+++ b/src/Infrastructure/Windows/WindowDialogs.cs
@@ -3,7 +3,6 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Sqlbi.Bravo.Infrastructure.Extensions;
-using Sqlbi.Bravo.Infrastructure.Helpers;
 using Sqlbi.Bravo.Infrastructure.Windows.Interop;
 
 namespace Sqlbi.Bravo.Infrastructure.Windows;
@@ -127,58 +126,5 @@ internal class ColorPickerDialog
         {
             Marshal.FreeCoTaskMem(lpCustColors);
         }
-    }
-}
-
-internal class MessageDialog
-{
-    public static void Show(string heading, string text)
-    {
-        var appIcon = Icon.ExtractAssociatedIcon(AppEnvironment.ProcessPath);
-        var icon = new TaskDialogIcon(appIcon!);
-
-        var page = new TaskDialogPage()
-        {
-            Caption = AppEnvironment.ApplicationMainWindowTitle,
-            Heading = heading,
-            Text = text,
-            Icon = icon,
-            AllowCancel = true
-        };
-
-        var hwndOwner = ProcessHelper.GetCurrentProcessMainWindowHandle();
-        _ = TaskDialog.ShowDialog(hwndOwner, page, TaskDialogStartupLocation.CenterScreen);
-    }
-
-    public static TaskDialogButton ShowDialog(string heading, string? text, string? footnoteText, bool allowCancel, params TaskDialogButton[] buttons)
-    {
-        var appIcon = Icon.ExtractAssociatedIcon(AppEnvironment.ProcessPath);
-        var icon = new TaskDialogIcon(appIcon!);
-
-        var page = new TaskDialogPage()
-        {
-            Caption = AppEnvironment.ApplicationMainWindowTitle,
-            Heading = heading,
-            Text = text,
-            Icon = icon,
-            AllowCancel = allowCancel, // || buttons.Any((button) => button == TaskDialogButton.Cancel),
-            AllowMinimize = false
-        };
-
-        if (footnoteText is not null)
-        {
-            page.Footnote = new TaskDialogFootnote()
-            {
-                Text = footnoteText,
-            };
-        }
-
-        foreach (var button in buttons)
-            page.Buttons.Add(button);
-
-        var hwndOwner = ProcessHelper.GetCurrentProcessMainWindowHandle();
-        var clickedButton = TaskDialog.ShowDialog(hwndOwner, page, TaskDialogStartupLocation.CenterScreen);
-
-        return clickedButton;
     }
 }

--- a/src/Models/ExportData/ExportDataSettings.cs
+++ b/src/Models/ExportData/ExportDataSettings.cs
@@ -44,12 +44,6 @@ public class ExportDelimitedTextSettings : ExportDataSettings
     /// </summary>
     [JsonPropertyName("quoteStringFields")]
     public bool QuoteStringFields { get; set; } = false;
-
-    /// <summary>
-    /// Specifies whether to export the data to a subfolder with the same name as the source <see cref="IDataModel{T}"/>
-    /// </summary>
-    [JsonPropertyName("createSubfolder")]
-    public bool CreateSubfolder { get; set; } = false;
 }
 
 public class ExportExcelSettings : ExportDataSettings

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Sqlbi.Bravo.Host;
-using Sqlbi.Bravo.Infrastructure.Helpers;
+using Sqlbi.Bravo.Infrastructure.Diagnostics;
 using Sqlbi.Bravo.Infrastructure.Telemetry;
 
 namespace Sqlbi.Bravo;
@@ -30,7 +30,11 @@ internal static class Program
         catch (Exception ex)
         {
             TelemetryService.Instance.TrackException(ex);
-            ExceptionHelper.ShowDialog(ex);
+
+            var report = ErrorReport.Create(ex);
+            report.TrySave();
+            ErrorReportDialog.Show(report);
+
             throw;
         }
     }

--- a/src/Scripts/controllers/host.ts
+++ b/src/Scripts/controllers/host.ts
@@ -131,7 +131,6 @@ export interface ExportDelimitedTextSettings {
     unicodeEncoding: boolean
     delimiter?: string
     quoteStringFields: boolean
-    createSubfolder: boolean
 }
 
 export interface ExportExcelSettings {

--- a/src/Scripts/model/i18n/cz.ts
+++ b/src/Scripts/model/i18n/cz.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Kódování",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Ušetřete v podsložce",
-        [_.exportDataCSVFolderDesc]: "Uložte generované soubory CSV v podsložce.",
         [_.exportDataCSVQuote]: "Uzavřete textový řetězec do uvozovek",
         [_.exportDataCSVQuoteDesc]: "Ujistěte se, že každý řetězec je uzavřen do dvojitých uvozovek.",
         [_.exportDataExcelCreateExportSummary]: "Exportovat souhrn",

--- a/src/Scripts/model/i18n/da.ts
+++ b/src/Scripts/model/i18n/da.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Tegnsæt",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Gem i en undermappe",
-        [_.exportDataCSVFolderDesc]: "Gem genererede CSV -filer i en undermappe.",
         [_.exportDataCSVQuote]: "Afgræns strenge med citationstegn",
         [_.exportDataCSVQuoteDesc]: "Sørger for at strenge er afgrænset af citationstegn.",
         [_.exportDataExcelCreateExportSummary]: "Eksport Opsummering",

--- a/src/Scripts/model/i18n/de.ts
+++ b/src/Scripts/model/i18n/de.ts
@@ -184,8 +184,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Kodierung",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "In einem Unterordner sparen",
-        [_.exportDataCSVFolderDesc]: "Speichern Sie generierte CSV -Dateien in einem Unterordner.",
         [_.exportDataCSVQuote]: "Zeichenketten in Anführungszeichen einschließen",
         [_.exportDataCSVQuoteDesc]: "Stellt sicher, dass jede Zeichenkette in doppelte Anführungszeichen gesetzt wird.",
         [_.exportDataExcelCreateExportSummary]: "Export Zusammenfassung",

--- a/src/Scripts/model/i18n/en.ts
+++ b/src/Scripts/model/i18n/en.ts
@@ -185,8 +185,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Encoding",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Save in a Subfolder",
-        [_.exportDataCSVFolderDesc]: "Save generated CSV files in a subfolder.",
         [_.exportDataCSVQuote]: "Enclose Strings in Quotes",
         [_.exportDataCSVQuoteDesc]: "Make sure every string is enclosed in double quotes.",
         [_.exportDataExcelCreateExportSummary]: "Export Summary",

--- a/src/Scripts/model/i18n/es.ts
+++ b/src/Scripts/model/i18n/es.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tabulador",
         [_.exportDataCSVEncoding]: "Codificación",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Ahorrar en una subcarpeta",
-        [_.exportDataCSVFolderDesc]: "Guarde los archivos CSV generados en una subcarpeta.",
         [_.exportDataCSVQuote]: "Encerrar la cadena de datos entre comillas",
         [_.exportDataCSVQuoteDesc]: "Hay que asegurarse de que cada cadena de datos esté encerrada entre comillas dobles.",
         [_.exportDataExcelCreateExportSummary]: "Exportar el resumen",

--- a/src/Scripts/model/i18n/fa.ts
+++ b/src/Scripts/model/i18n/fa.ts
@@ -186,8 +186,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "رمزگذاری",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "ذخیره در زیرپوشه",
-        [_.exportDataCSVFolderDesc]: "ذخیره اکسل خروجی گرفته شده در زیرپوشه.",
         [_.exportDataCSVQuote]: "رشته ها را در دو گیومه قرار دهید",
         [_.exportDataCSVQuoteDesc]: "اطمینان حاصل کنید که هر رشته در گیومه های دوتایی محصور شده است.",
         [_.exportDataExcelCreateExportSummary]: "خلاصه خروجی گرفتن",

--- a/src/Scripts/model/i18n/fr.ts
+++ b/src/Scripts/model/i18n/fr.ts
@@ -184,8 +184,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tabulation",
         [_.exportDataCSVEncoding]: "Encodage",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Sauver dans un sous-dossier",
-        [_.exportDataCSVFolderDesc]: "Enregistrer les fichiers CSV générés dans un sous-dossier.",
         [_.exportDataCSVQuote]: "Mettre les chaînes de caractères entre apostrophes",
         [_.exportDataCSVQuoteDesc]: "S'assurer que chaque chaîne de caractères est mise entre guillemets.",
         [_.exportDataExcelCreateExportSummary]: "Exporter le résumé",

--- a/src/Scripts/model/i18n/gr.ts
+++ b/src/Scripts/model/i18n/gr.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Χαρακτήρας Tab",
         [_.exportDataCSVEncoding]: "Κωδικοποίηση",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Αποθήκευση σε υποψήφιο",
-        [_.exportDataCSVFolderDesc]: "Αποθηκεύστε τα δημιουργημένα αρχεία CSV σε έναν υποτονό.",
         [_.exportDataCSVQuote]: "Βάλε εισαγωγικά στα αλφαριθμητικά",
         [_.exportDataCSVQuoteDesc]: "Βεβαιώσου ότι τα αλφαριθμητικά είναι μέσα σε διπλά εισαγωγικά.",
         [_.exportDataExcelCreateExportSummary]: "Εξαγωγή Περίληψης",

--- a/src/Scripts/model/i18n/it.ts
+++ b/src/Scripts/model/i18n/it.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Codifica",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Salva in una sottocartella",
-        [_.exportDataCSVFolderDesc]: "Salva file CSV generati in una sottocartella.",
         [_.exportDataCSVQuote]: "Stringhe tra virgolette",
         [_.exportDataCSVQuoteDesc]: "Racchiudi tutte le stringhe tra virgolette.",
         [_.exportDataExcelCreateExportSummary]: "Foglio di Riepilogo ",

--- a/src/Scripts/model/i18n/nl.ts
+++ b/src/Scripts/model/i18n/nl.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Codering",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Opslaan in een submap",
-        [_.exportDataCSVFolderDesc]: "Opslaan gegenereerde CSV -bestanden in een submap.",
         [_.exportDataCSVQuote]: "Tekenreeksen tussen aanhalingstekens insluiten",
         [_.exportDataCSVQuoteDesc]: "Zorg ervoor dat elke tekenreeks tussen dubbele aanhalingstekens staat.",
         [_.exportDataExcelCreateExportSummary]: "Exporteer samenvatting",

--- a/src/Scripts/model/i18n/pl.ts
+++ b/src/Scripts/model/i18n/pl.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tab",
         [_.exportDataCSVEncoding]: "Kodowanie",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Zapisz w podfolderze",
-        [_.exportDataCSVFolderDesc]: "Zapisz wygenerowane pliki CSV w podfolderze.",
         [_.exportDataCSVQuote]: "Umieść tekst w cudzysłowie",
         [_.exportDataCSVQuoteDesc]: "Upewnij się, że każdy tekst umieszczony jest w cudzysłowie.",
         [_.exportDataExcelCreateExportSummary]: "Eksportuj podsumowanie",

--- a/src/Scripts/model/i18n/pt.ts
+++ b/src/Scripts/model/i18n/pt.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Tabulador",
         [_.exportDataCSVEncoding]: "Codificação",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Salvar em uma subpasta",
-        [_.exportDataCSVFolderDesc]: "Salvar arquivos CSV gerados em uma subpasta.",
         [_.exportDataCSVQuote]: "Coloque Texto Entre Aspas",
         [_.exportDataCSVQuoteDesc]: "Certifique-se que todo o texto está entre aspas.",
         [_.exportDataExcelCreateExportSummary]: "Exportar Sumário",

--- a/src/Scripts/model/i18n/ru.ts
+++ b/src/Scripts/model/i18n/ru.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Табуляция",
         [_.exportDataCSVEncoding]: "Кодировка",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Сохранить в подпапке",
-        [_.exportDataCSVFolderDesc]: "Сохраните сгенерированные файлы CSV в подпапке.",
         [_.exportDataCSVQuote]: "Заключить строки в кавычки",
         [_.exportDataCSVQuoteDesc]: "Убедитесь, что каждая строка заключена в двойные кавычки.",
         [_.exportDataExcelCreateExportSummary]: "Экспорт сведенных данных",

--- a/src/Scripts/model/i18n/tr.ts
+++ b/src/Scripts/model/i18n/tr.ts
@@ -184,8 +184,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Sekme",
         [_.exportDataCSVEncoding]: "Dil Kodlaması",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Bir alt klasöre kaydedin",
-        [_.exportDataCSVFolderDesc]: "Oluşturulan CSV dosyalarını bir alt klasöre kaydedin.",
         [_.exportDataCSVQuote]: "Dizeleri Çift Tırnak İçine Alın",
         [_.exportDataCSVQuoteDesc]: "Her dizenin çift tırnak içine alındığından emin olun.",
         [_.exportDataExcelCreateExportSummary]: "Dışa Aktarma Özeti",

--- a/src/Scripts/model/i18n/uk.ts
+++ b/src/Scripts/model/i18n/uk.ts
@@ -183,8 +183,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "Табуляція",
         [_.exportDataCSVEncoding]: "Кодування",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "Зберегти в підпапці",
-        [_.exportDataCSVFolderDesc]: "Збережіть сформовані CSV-файли в підпапці.",
         [_.exportDataCSVQuote]: "Взяти рядки в лапки",
         [_.exportDataCSVQuoteDesc]: "Переконайтеся, що кожен рядок укладений у подвійні лапки.",
         [_.exportDataExcelCreateExportSummary]: "Експортувати звіт",

--- a/src/Scripts/model/i18n/zh.ts
+++ b/src/Scripts/model/i18n/zh.ts
@@ -182,8 +182,6 @@ const locale: Locale = {
         [_.exportDataCSVDelimiterTab]: "制表符",
         [_.exportDataCSVEncoding]: "编码格式",
         [_.exportDataCSVEncodingDesc]: "",
-        [_.exportDataCSVFolder]: "保存在子文件夹中",
-        [_.exportDataCSVFolderDesc]: "将生成的CSV文件保存在子文件夹中。",
         [_.exportDataCSVQuote]: "用引号包含字符串",
         [_.exportDataCSVQuoteDesc]: "确保每一个字符串都包含在双引号中",
         [_.exportDataExcelCreateExportSummary]: "导出记录日志",

--- a/src/Scripts/model/strings.ts
+++ b/src/Scripts/model/strings.ts
@@ -177,8 +177,6 @@ export enum strings {
     exportDataCSVDelimiterTab,
     exportDataCSVEncoding,
     exportDataCSVEncodingDesc,
-    exportDataCSVFolder,
-    exportDataCSVFolderDesc,
     exportDataCSVQuote,
     exportDataCSVQuoteDesc,
     exportDataExcelCreateExportSummary,

--- a/src/Scripts/view/scene-export-data.ts
+++ b/src/Scripts/view/scene-export-data.ts
@@ -30,7 +30,6 @@ interface ExportSettings {
     delimiter: string
     customDelimiter: string
     quoteStringFields: boolean
-    createSubfolder: boolean
 }
 
 export class ExportDataScene extends DocScene {
@@ -55,8 +54,7 @@ export class ExportDataScene extends DocScene {
             encoding: "utf8",
             delimiter: "",
             customDelimiter: "",
-            quoteStringFields: false,
-            createSubfolder: false
+            quoteStringFields: false
         });
     }
 
@@ -189,17 +187,6 @@ export class ExportDataScene extends DocScene {
                 parent: "format",
                 name: i18n(strings.exportDataCSVQuote),
                 description: i18n(strings.exportDataCSVQuoteDesc),
-                type: OptionType.switch,
-                toggledBy: {
-                    option: "format",
-                    value: ExportDataFormat.Csv
-                }
-            },
-            {
-                option: "createSubfolder",
-                parent: "format",
-                name: i18n(strings.exportDataCSVFolder),
-                description: i18n(strings.exportDataCSVFolderDesc),
                 type: OptionType.switch,
                 toggledBy: {
                     option: "format",
@@ -473,8 +460,7 @@ export class ExportDataScene extends DocScene {
                 tables: tables,
                 unicodeEncoding: (this.config.options.encoding == "utf16"),
                 delimiter: delimiter,
-                quoteStringFields: this.config.options.quoteStringFields,
-                createSubfolder: this.config.options.createSubfolder
+                quoteStringFields: this.config.options.quoteStringFields
             };
 
             if (this.doc.type == DocType.dataset) {

--- a/test/Bravo.Tests/Infrastructure/Windows/TaskDialogBuilderTests.cs
+++ b/test/Bravo.Tests/Infrastructure/Windows/TaskDialogBuilderTests.cs
@@ -1,0 +1,42 @@
+﻿using System.Windows.Forms;
+using Sqlbi.Bravo.Infrastructure.Windows.Dialogs;
+using Xunit;
+
+namespace Bravo.Tests.Infrastructure.Windows;
+
+public class TaskDialogBuilderTests
+{
+    [Fact]
+    public void Build_CopiesEverySettingToThePage()
+    {
+        var first = new TaskDialogCommandLinkButton("first", "first description");
+        var second = new TaskDialogButton("second");
+
+        var page = TaskDialogBuilder.Create()
+            .WithCaption("caption")
+            .WithHeading("heading")
+            .WithText("text")
+            .WithIcon(TaskDialogIcon.Warning)
+            .WithFootnote("footnote", TaskDialogIcon.Information)
+            .WithExpander("details", expanded: true, TaskDialogExpanderPosition.AfterFootnote, expandedButtonText: "Hide", collapsedButtonText: "Show")
+            .AddButtons(first, second)
+            .WithDefaultButton(second)
+            .WithSizeToContent()
+            .Build();
+
+        Assert.Equal("caption", page.Caption);
+        Assert.Equal("heading", page.Heading);
+        Assert.Equal("text", page.Text);
+        Assert.Same(TaskDialogIcon.Warning, page.Icon);
+        Assert.Equal("footnote", page.Footnote?.Text);
+        Assert.Same(TaskDialogIcon.Information, page.Footnote?.Icon);
+        Assert.Equal("details", page.Expander?.Text);
+        Assert.True(page.Expander?.Expanded);
+        Assert.Equal(TaskDialogExpanderPosition.AfterFootnote, page.Expander?.Position);
+        Assert.Equal("Hide", page.Expander?.ExpandedButtonText);
+        Assert.Equal("Show", page.Expander?.CollapsedButtonText);
+        Assert.Equal(new TaskDialogButton[] { first, second }, page.Buttons);
+        Assert.Same(second, page.DefaultButton);
+        Assert.True(page.SizeToContent);
+    }
+}


### PR DESCRIPTION
Unhandled exceptions now create ErrorReport.txt in the application data folder with exception and environment details. The error dialog explains the failure, links to the report, and lets the user copy it to the clipboard. Windows Event Log reporting has been removed. Task dialogs now use a small fluent builder. The WebView2 Runtime prompt has also been simplified, following the .NET apphost pattern with a single download action and additional details in the expander. The CSV export no longer includes the "Save in a Subfolder" option, removing an unnecessary choice and its related conflict handling.